### PR TITLE
Fix string to LocalData ISO convertion

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
@@ -10,6 +10,7 @@ import org.springframework.boot.info.GitProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.format.datetime.standard.TemporalAccessorParser;
 
 import ca.gov.dtsstn.passport.api.config.properties.SwaggerUiProperties;
 import ca.gov.dtsstn.passport.api.config.properties.SwaggerUiProperties.AuthenticationProperties.OAuthProperties.Scope;

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/PassportStatus.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/PassportStatus.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 
 import org.immutables.value.Value.Immutable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.lang.Nullable;
 
 /**
@@ -45,6 +46,7 @@ public interface PassportStatus extends Serializable {
 	String getApplicationRegisterSid();
 
 	@Nullable
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 	LocalDate getDateOfBirth();
 
 	@Nullable

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PassportStatusModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PassportStatusModel.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.PastOrPresent;
 
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.hateoas.Links;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.core.Relation;
@@ -97,6 +98,7 @@ public abstract class PassportStatusModel extends RepresentationModel<PassportSt
 	@NotNull(message = "dateOfBirth is required; it must not be null")
 	@PastOrPresent(message = "dateOfBirth must be a date in the past")
 	@Schema(description = "The date of birth of the passport applicant in ISO-8601 format.", example = "2000-01-01", required = true)
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 	public abstract LocalDate getDateOfBirth();
 
 	@Nullable

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PassportStatusSearchModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PassportStatusSearchModel.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.immutables.value.Value.Immutable;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import ca.gov.dtsstn.passport.api.web.annotation.Parameter;
 
@@ -32,6 +33,7 @@ public interface PassportStatusSearchModel extends Serializable {
 
 	@NotNull(message = "dateOfBirth must not be null or blank")
 	@Parameter(description = "The date of birth of the passport applicant in ISO-8601 format.", example = "2000-01-01", required = true)
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 	LocalDate getDateOfBirth();
 
 }


### PR DESCRIPTION
I notice the `String` to `LocalDate` conversion with ISO date `2000-01-01` wasn't working in my browser but it works with curl and in insomnia. I debugged `TemporalAccessorParser` class and notice the `Locale` used from my browser was `en-US` but `en-CA` with curl and insomia. It's why the conversion was failing. I added `@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)` where `LocalDate` was used and it fix the issue. @gregory-j-baker might have a better solution but it work for the moment.

Here's the GET url: http://localhost:8080/api/v1/passport-statuses/_search?dateOfBirth=2000-01-01