### PR TITLE
Fix OWASP ZAP warning about swagger

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
@@ -25,9 +25,9 @@ public class SpringDocConfig {
 
 	private static final Logger log = LoggerFactory.getLogger(SpringDocConfig.class);
 
-	public static final String HTTP = "JSON Web Token";
+	public static final String HTTP = "JSON-Web-Token";
 
-	public static final String OAUTH = "Azure Active Directory";
+	public static final String OAUTH = "Azure-Active-Directory";
 
 	@Bean OpenApiCustomiser openApiCustomizer(Environment environment, GitProperties gitProperties, SwaggerUiProperties swaggerUiProperties) {
 		log.info("Creating 'openApiCustomizer' bean");


### PR DESCRIPTION
OWASP ZAP warned that the security definition in the OpenAPI spec didn't meet the required naming pattern. This fixes that issue.