### PR TITLE
Permanently remove swagger server list

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.Scopes;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
-import io.swagger.v3.oas.models.servers.Server;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
@@ -59,15 +58,6 @@ public class SpringDocConfig {
 							.refreshUrl(swaggerUiProperties.authentication().oauth().tokenUrl())
 							.scopes(new Scopes().addString(swaggerUiProperties.authentication().oauth().clientId() + "/.default", "Default scope"))
 							.tokenUrl(swaggerUiProperties.authentication().oauth().tokenUrl()))));
-
-			if (false) {
-				// TODO :: GjB :: disabling because something's broken
-				swaggerUiProperties.servers().stream()
-					.map(server -> new Server()
-					.description(server.description())
-					.url(server.url()))
-					.forEach(openApi::addServersItem);
-			}
 		};
 	}
 

--- a/src/main/resources/application-local.yaml.sample
+++ b/src/main/resources/application-local.yaml.sample
@@ -33,9 +33,3 @@ application:
     oauth:
       client-id: de3625ec-c6e6-46a6-b761-7b1039ab546a
       tenant-id: 9ed55846-8a81-4246-acd8-b1a01abfc0d1
-  swagger-ui:
-    servers:
-      - description: Development environment
-        url: https://passport-status-api.dev.dev-rhp.dts-stn.com/
-      - description: Staging environment
-        url: https://passport-status-api.staging.dev-rhp.dts-stn.com/


### PR DESCRIPTION
After doing some debugging I've realized that specifying servers in the configuration will break making calls to localhost. So I'm removing it.