### PR TITLE
Add Jackson as JMS message converter

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
@@ -2,7 +2,6 @@ package ca.gov.dtsstn.passport.api.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
@@ -16,10 +15,12 @@ public class JmsConfig {
 
 	private static final Logger log = LoggerFactory.getLogger(JmsConfig.class);
 
-	@Autowired ObjectMapper objectMapper;
-
 	@Bean MessageConverter jacksonJmsMessageConverter() {
 		log.info("Creating 'jacksonJmsMessageConverter' bean");
+
+		final var objectMapper = new ObjectMapper();
+		objectMapper.findAndRegisterModules();
+
 		final var converter = new MappingJackson2MessageConverter();
 		converter.setTargetType(MessageType.TEXT);
 		converter.setTypeIdPropertyName("_type");

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
@@ -10,6 +10,9 @@ import org.springframework.jms.support.converter.MessageType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)
+ */
 @Configuration
 public class JmsConfig {
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
@@ -2,6 +2,7 @@ package ca.gov.dtsstn.passport.api.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
@@ -9,23 +10,20 @@ import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.converter.MessageType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
 public class JmsConfig {
 
 	private static final Logger log = LoggerFactory.getLogger(JmsConfig.class);
 
+	@Autowired ObjectMapper objectMapper;
+
 	@Bean MessageConverter jacksonJmsMessageConverter() {
 		log.info("Creating 'jacksonJmsMessageConverter' bean");
-
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.registerModule(new JavaTimeModule());
-
-		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		final var converter = new MappingJackson2MessageConverter();
 		converter.setTargetType(MessageType.TEXT);
 		converter.setTypeIdPropertyName("_type");
-		converter.setObjectMapper(mapper);
+		converter.setObjectMapper(objectMapper);
 		return converter;
 	}
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/JmsConfig.java
@@ -1,0 +1,32 @@
+package ca.gov.dtsstn.passport.api.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.MessageType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JmsConfig {
+
+	private static final Logger log = LoggerFactory.getLogger(JmsConfig.class);
+
+	@Bean MessageConverter jacksonJmsMessageConverter() {
+		log.info("Creating 'jacksonJmsMessageConverter' bean");
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		converter.setTargetType(MessageType.TEXT);
+		converter.setTypeIdPropertyName("_type");
+		converter.setObjectMapper(mapper);
+		return converter;
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/PassportStatus.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/PassportStatus.java
@@ -7,6 +7,8 @@ import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
 import org.springframework.lang.Nullable;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 /**
  * Domain object that represents a passport application status.
  * <p>
@@ -17,6 +19,7 @@ import org.springframework.lang.Nullable;
  */
 @Immutable
 @Style(validationMethod = ValidationMethod.NONE)
+@JsonDeserialize(as = ImmutablePassportStatus.class)
 public interface PassportStatus extends AbstractDomainObject {
 
 	public enum Status { APPROVED, IN_EXAMINATION, REJECTED }


### PR DESCRIPTION
Add Jackson as JMS message converter to store JSON instead of serialized Java Object in the message queue.

`@JsonDeserialize(as = ImmutablePassportStatus.class)` is added otherwise Jackson cannot deserialize the immutable interface.