### PR TITLE
Add NIEM models for passport (aka "certificate")

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/BirthDate.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/BirthDate.java
@@ -1,0 +1,41 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "BirthDate")
+public class BirthDate implements Serializable {
+
+	@JsonProperty("Date")
+	@PastOrPresent(message = "Date must be in the past")
+	@NotNull(message = "Date is required; it must not be null")
+	@Schema(description = "The birth date of the certificate applicant in ISO 8601 format.", example = "2000-01-01")
+	private LocalDate date;
+
+	public LocalDate getDate() {
+		return date;
+	}
+
+	public void setDate(LocalDate date) {
+		this.date = date;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplication.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplication.java
@@ -1,0 +1,78 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "CertificateApplication")
+public class CertificateApplication implements Serializable {
+
+	@JsonProperty("CertificateApplicationApplicant")
+	@NotNull(message = "CertificateApplicationApplicant is required; it must not be null")
+	private CertificateApplicationApplicant certificateApplicationApplicant;
+
+	@JsonProperty("CertificateApplicationDate")
+	@NotNull(message = "CertificateApplicationDate is required; it must not be null")
+	private CertificateApplicationDate certificateApplicationDate;
+
+	@JsonProperty("CertificateApplicationIdentification")
+	@NotNull(message = "CertificateApplicationIdentification is required; it must not be null")
+	@Size(min = 2, max = 2, message = "CertificateApplicationIdentification must be an array with the exactly [IdentificationCategoryText='Application Register SID'] and [IdentificationCategoryText='File Number']")
+	@Schema(example = "[{\"IdentificationCategoryText\": \"Application Register SID\", \"IdentificationID\": \"ABCD1234\" },{ \"IdentificationCategoryText\": \"File Number\", \"IdentificationID\": \"ABCD1234\" }]")
+	private List<CertificateApplicationIdentification> certificateApplicationIdentifications;
+
+	@JsonProperty("CertificateApplicationStatus")
+	@NotNull(message = "CertificateApplicationStatus is required; it must not be null")
+	private CertificateApplicationStatus certificateApplicationStatus;
+
+	public CertificateApplicationApplicant getCertificateApplicationApplicant() {
+		return certificateApplicationApplicant;
+	}
+
+	public void setCertificateApplicationApplicant(CertificateApplicationApplicant certificateApplicationApplicant) {
+		this.certificateApplicationApplicant = certificateApplicationApplicant;
+	}
+
+	public CertificateApplicationDate getCertificateApplicationDate() {
+		return certificateApplicationDate;
+	}
+
+	public void setCertificateApplicationDate(CertificateApplicationDate certificateApplicationDate) {
+		this.certificateApplicationDate = certificateApplicationDate;
+	}
+
+	public List<CertificateApplicationIdentification> getCertificateApplicationIdentifications() {
+		return certificateApplicationIdentifications;
+	}
+
+	public void setCertificateApplicationIdentifications(
+			List<CertificateApplicationIdentification> certificateApplicationIdentifications) {
+		this.certificateApplicationIdentifications = certificateApplicationIdentifications;
+	}
+
+	public CertificateApplicationStatus getCertificateApplicationStatus() {
+		return certificateApplicationStatus;
+	}
+
+	public void setCertificateApplicationStatus(CertificateApplicationStatus certificateApplicationStatus) {
+		this.certificateApplicationStatus = certificateApplicationStatus;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationApplicant.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationApplicant.java
@@ -1,0 +1,61 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "CertificateApplicationApplicant")
+public class CertificateApplicationApplicant implements Serializable {
+
+	@JsonProperty("BirthDate")
+	@NotNull(message = "BirthDate is required; it must not be null")
+	private BirthDate birthDate;
+
+	@JsonProperty("PersonName")
+	@NotNull(message = "PersonName is required; it must not be null")
+	private PersonName personName;
+
+	@JsonProperty("PersonContactInformation")
+	@NotNull(message = "PersonContactInformation is required; it must not be null")
+	private PersonContactInformation personContactInformation;
+
+	public BirthDate getBirthDate() {
+		return birthDate;
+	}
+
+	public void setBirthDate(BirthDate birthDate) {
+		this.birthDate = birthDate;
+	}
+
+	public PersonName getPersonName() {
+		return personName;
+	}
+
+	public void setPersonName(PersonName personName) {
+		this.personName = personName;
+	}
+
+	public PersonContactInformation getPersonContactInformation() {
+		return personContactInformation;
+	}
+
+	public void setPersonContactInformation(PersonContactInformation personContactInformation) {
+		this.personContactInformation = personContactInformation;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationDate.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationDate.java
@@ -1,0 +1,39 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "CertificateApplicationDate")
+public class CertificateApplicationDate implements Serializable {
+
+	@JsonProperty("Date")
+	@NotNull(message = "Date is required; it must not be null")
+	@Schema(description = "The date the certificate application was created in ISO 8601 format.", example = "2020-01-01")
+	private LocalDate date;
+
+	public LocalDate getDate() {
+		return date;
+	}
+
+	public void setDate(LocalDate date) {
+		this.date = date;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentification.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentification.java
@@ -1,0 +1,51 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "CertificateApplicationIdentification")
+public class CertificateApplicationIdentification implements Serializable {
+
+	@JsonProperty("IdentificationCategoryText")
+	@NotNull(message = "IdentificationCategoryText is required; it must not be null")
+	@Schema(description = "A human readable description of the certificate application ID entry.", example = "Application Register SID")
+	private String identificationCategoryText;
+
+	@JsonProperty("IdentificationID")
+	@NotNull(message = "IdentificationID is required; it must not be null")
+	@Schema(description = "The value of the certificate application ID entry.", example = "ABCD1234")
+	private String identificationId;
+
+	public String getIdentificationCategoryText() {
+		return identificationCategoryText;
+	}
+
+	public void setIdentificationCategoryText(String identificationCategoryText) {
+		this.identificationCategoryText = identificationCategoryText;
+	}
+
+	public String getIdentificationId() {
+		return identificationId;
+	}
+
+	public void setIdentificationId(String identificationId) {
+		this.identificationId = identificationId;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationStatus.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationStatus.java
@@ -1,0 +1,38 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "CertificateApplicationStatus")
+public class CertificateApplicationStatus implements Serializable {
+
+	@JsonProperty("StatusCode")
+	@NotBlank(message = "StatusCode is required; it must not null or blank")
+	@Schema(description = "The certificate application status code.", example = "000")
+	private String statusCode;
+
+	public String getStatusCode() {
+		return statusCode;
+	}
+
+	public void setStatusCode(String statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CreateCertificateApplicationRequest.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CreateCertificateApplicationRequest.java
@@ -1,0 +1,37 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "CreateCertificateApplicationRequest")
+public class CreateCertificateApplicationRequest implements Serializable {
+
+	@JsonProperty("CertificateApplication")
+	@NotNull(message = "CertificateApplication is required; it must not be null")
+	private CertificateApplication certificateApplication;
+
+	public CertificateApplication getCertificateApplication() {
+		return certificateApplication;
+	}
+
+	public void setCertificateApplication(CertificateApplication certificateApplication) {
+		this.certificateApplication = certificateApplication;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonContactInformation.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonContactInformation.java
@@ -1,0 +1,42 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "PersonContactInformation")
+public class PersonContactInformation implements Serializable {
+
+	@JsonProperty("ContactEmailID")
+	@Email(message = "ContactEmailID must be a valid email address")
+	@NotBlank(message = "ContactEmailID is required; it must not be null or blank")
+	@Pattern(message = "email must be a valid email address", regexp = "[^@]+@[^@]+\\.[^@]+")
+	@Schema(description = "The email address of the certificate applicant.", example = "user@example.com")
+	private String contactEmailId;
+
+	public String getContactEmailId() {
+		return contactEmailId;
+	}
+
+	public void setContactEmailId(String contactEmailId) {
+		this.contactEmailId = contactEmailId;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonName.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonName.java
@@ -1,0 +1,55 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Schema(name = "PersonName")
+public class PersonName implements Serializable {
+
+	@JsonProperty("PersonGivenName")
+	@NotNull(message = "PersonGivenName is required; it must not be null")
+	@Size(min = 1, max = 1, message = "PersonGivenName must be an array of size 1")
+	@Schema(description = "A set of given names of the certificate applicant.", example = "[\"John\"]")
+	private List<String> personGivenNames;
+
+	@JsonProperty("PersonSurName")
+	@NotBlank(message = "PersonSurName is required; it must not be null or blank")
+	@Schema(description = "The surname of the certificate applicant.", example = "Doe")
+	private String personSurname;
+
+	public List<String> getPersonGivenNames() {
+		return personGivenNames;
+	}
+
+	public void setPersonGivenNames(List<String> personGivenNames) {
+		this.personGivenNames = personGivenNames;
+	}
+
+	public String getPersonSurname() {
+		return personSurname;
+	}
+
+	public void setPersonSurname(String personSurname) {
+		this.personSurname = personSurname;
+	}
+
+	@Override
+	public String toString() {
+		return ReflectionToStringBuilder.toString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+	}
+
+}


### PR DESCRIPTION
## ⚠ This is a NON-FUNCTIONAL incremental update to prepare for upcoming changes to the API models.

The intent of this PR is to introduce NIEM compliant models for a passport application (known as a _certificate_ in NIEM parlance).

**They are not used yet, and are submitted here simply to make future FUNCTIONAL PRs easier to manage.**

The models in this PR conform to the following data schema provided by the ESDC interop team:

``` json
{
  "CertificateApplication": {
    "CertificateApplicationApplicant": {
      "BirthDate": {
        "Date": "2000-01-01"
      },
      "PersonContactInformation": {
        "ContactEmailID": "user@example.com"
      },
      "PersonName": {
        "PersonGivenName": [
          "John"
        ],
        "PersonSurName": "Doe"
      }
    },
    "CertificateApplicationDate": {
      "Date": "2022-01-01"
    },
    "CertificateApplicationIdentification": [
      {
        "IdentificationCategoryText": "Application Register SID",
        "IdentificationID": "ABCD1234"
      },
      {
        "IdentificationCategoryText": "File Number",
        "IdentificationID": "ABCD1234"
      }
    ],
    "CertificateApplicationStatus": {
      "StatusCode": "1"
    }
  }
}
```

And here is the OpenAPI representation, as presented by Swagger UI (as evidence of compliance):

![image](https://user-images.githubusercontent.com/48123208/197081676-163fd38c-e12c-430f-a7f3-15f3e1bf0444.png)
