### PR TITLE
Update CertificateApplicationIdentification validation

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentificationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentificationModel.java
@@ -27,13 +27,14 @@ public interface CertificateApplicationIdentificationModel extends Serializable 
 
 	static final String FILE_NUMBER_CATEGORY_TEXT = "File Number";
 
+	static final String MANIFEST_NUMBER_CATEGORY_TEXT = "Manifest Number";
+
 	@JsonProperty("IdentificationCategoryText")
 	@NotNull(message = "IdentificationCategoryText is required; it must not be null")
 	@Schema(description = "A human readable description of the certificate application ID entry.", example = "Application Register SID")
 	String getIdentificationCategoryText();
 
 	@JsonProperty("IdentificationID")
-	@NotNull(message = "IdentificationID is required; it must not be null")
 	@Size(max = 32, message = "IdentificationID must be 32 characters or less")
 	@Schema(description = "The value of the certificate application ID entry.", example = "ABCD1234")
 	String getIdentificationId();

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationModel.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
@@ -18,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import ca.gov.dtsstn.passport.api.web.annotation.Authorities;
+import ca.gov.dtsstn.passport.api.web.validation.CertificateApplicationIdentification;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -44,8 +44,8 @@ public interface CertificateApplicationModel extends Serializable {
 	@JsonView({ Authorities.AuthenticatedView.class })
 	@JsonProperty("CertificateApplicationIdentification")
 	@NotNull(message = "CertificateApplicationIdentification is required; it must not be null")
-	@Size(min = 2, max = 2, message = "CertificateApplicationIdentification must be an array with the exactly [IdentificationCategoryText='Application Register SID'] and [IdentificationCategoryText='File Number']")
 	@Schema(example = "[{\"IdentificationCategoryText\": \"Application Register SID\", \"IdentificationID\": \"ABCD1234\" },{ \"IdentificationCategoryText\": \"File Number\", \"IdentificationID\": \"ABCD1234\" }]")
+	@CertificateApplicationIdentification(message = "CertificateApplicationIdentification must be an array with at least [IdentificationCategoryText='Application Register SID'] and [IdentificationCategoryText='File Number']")
 	default List<CertificateApplicationIdentificationModel> getCertificateApplicationIdentifications() {
 		return Collections.emptyList();
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentification.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentification.java
@@ -1,0 +1,25 @@
+package ca.gov.dtsstn.passport.api.web.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { CertificateApplicationIdentificationValidator.class })
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE_USE })
+public @interface CertificateApplicationIdentification {
+
+	String message();
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentificationValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentificationValidator.java
@@ -1,0 +1,45 @@
+package ca.gov.dtsstn.passport.api.web.validation;
+
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import ca.gov.dtsstn.passport.api.web.model.CertificateApplicationIdentificationModel;
+
+/**
+ * Checks that a collection of {@link CertificateApplicationIdentificationModel} has both
+ * {@code APPLICATION_REGISTER_SID_CATEGORY_TEXT} and {@code FILE_NUMBER_CATEGORY_TEXT} entries.
+ *
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Component
+public class CertificateApplicationIdentificationValidator implements ConstraintValidator<CertificateApplicationIdentification, Iterable<CertificateApplicationIdentificationModel>> {
+
+	@Override
+	public boolean isValid(Iterable<CertificateApplicationIdentificationModel> values, ConstraintValidatorContext context) {
+		if (values == null) { return true; }
+
+		final var hasApplicationRegisterSid = validateNotBlank(values, CertificateApplicationIdentificationModel.APPLICATION_REGISTER_SID_CATEGORY_TEXT);
+		final var hasFileNumber = validateNotBlank(values, CertificateApplicationIdentificationModel.FILE_NUMBER_CATEGORY_TEXT);
+
+		return hasApplicationRegisterSid && hasFileNumber;
+	}
+
+	protected boolean validateNotBlank(Iterable<CertificateApplicationIdentificationModel> certificateApplicationIdentifications, String identificationCategoryText) {
+		return StreamSupport.stream(certificateApplicationIdentifications.spliterator(), false)
+			.filter(byIdentificationCategoryText(identificationCategoryText)).findFirst()
+			.map(CertificateApplicationIdentificationModel::getIdentificationId)
+			.filter(StringUtils::hasText)
+			.isPresent();
+	}
+
+	protected Predicate<CertificateApplicationIdentificationModel> byIdentificationCategoryText(String applicationRegisterSidCategoryText) {
+		return certificateApplicationId -> applicationRegisterSidCategoryText.equals(certificateApplicationId.getIdentificationCategoryText());
+	}
+
+}


### PR DESCRIPTION
Allow `"IdentificationCategoryText": "Manifest Number"` to be sent as an optional (nullable or empty) entry.