### PR TITLE
Add http request repository filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ application:
       changelog-path: changelog.json  # classpath location of the changelog.json file generated during build
   http-request-repository:
     page-size: 100                    # number of http request/response trace requests to return from /actuator/httptrace
+    includeUrls:                      # list of URLs to include, in ant path style
+      - /**
+    excludeUrls:                      # list of URLs to exclude, in ant path style
+      - /actuator/health/liveness
+      - /actuator/health/readiness
   security:
     cors:
       allowed-headers:                # list of headers that a pre-flight request can list as allowed for use during an actual request

--- a/src/main/java/ca/gov/dtsstn/passport/api/actuate/PersistentHttpTraceRepository.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/actuate/PersistentHttpTraceRepository.java
@@ -1,6 +1,8 @@
 package ca.gov.dtsstn.passport.api.actuate;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -14,7 +16,9 @@ import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
 import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -32,11 +36,17 @@ import ca.gov.dtsstn.passport.api.data.entity.HttpRequestEntity;
 @ConfigurationProperties("application.http-request-repository")
 public class PersistentHttpTraceRepository implements HttpTraceRepository {
 
+	private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
 	private final HttpRequestRepository httpRequestRepository;
 
 	private final HttpTraceMapper httpTraceMapper = Mappers.getMapper(HttpTraceMapper.class);
 
 	private final InMemoryHttpTraceRepository inMemoryHttpTraceRepository;
+
+	private List<AntPathRequestMatcher> includeUrls = Collections.emptyList();
+
+	private List<AntPathRequestMatcher> excludeUrls = Collections.emptyList();
 
 	@Autowired // marks this constructor as the primary one spring will use
 	public PersistentHttpTraceRepository(HttpRequestRepository httpRequestRepository) {
@@ -54,8 +64,13 @@ public class PersistentHttpTraceRepository implements HttpTraceRepository {
 	@Override
 	public void add(HttpTrace httpTrace) {
 		Assert.notNull(httpTrace, "httpTrace is required; it must not be null");
+
 		inMemoryHttpTraceRepository.add(httpTrace);
-		Optional.ofNullable(httpTraceMapper.toEntity(httpTrace)).ifPresent(httpRequestRepository::save);
+
+		Optional.ofNullable(httpTrace)
+			.filter(this::shouldPersist)
+			.map(httpTraceMapper::toEntity)
+			.ifPresent(httpRequestRepository::save);
 	}
 
 	@Override
@@ -63,9 +78,35 @@ public class PersistentHttpTraceRepository implements HttpTraceRepository {
 		return inMemoryHttpTraceRepository.findAll();
 	}
 
+	protected String getPath(HttpTrace httpTrace) {
+		return httpTrace.getRequest().getUri().getPath();
+	}
+
+	protected boolean isIncluded(HttpTrace httpTrace) {
+		return includeUrls.isEmpty() || includeUrls.stream().anyMatch(includeUrl -> antPathMatcher.match(includeUrl.getPattern(), getPath(httpTrace)));
+	}
+
+	protected boolean isNotExcluded(HttpTrace httpTrace) {
+		return excludeUrls.stream().noneMatch(excludeUrl -> antPathMatcher.match(excludeUrl.getPattern(), getPath(httpTrace)));
+	}
+
 	public void setCapacity(int capacity) {
 		Assert.isTrue(capacity >= 0, "application.http-request-repository.capacity must be greater than or equal to zero");
 		inMemoryHttpTraceRepository.setCapacity(capacity);
+	}
+
+	public void setIncludeUrls(Collection<AntPathRequestMatcher> includeUrls) {
+		Assert.notNull(includeUrls, "includeUrls is required; it must not be null");
+		this.includeUrls = List.copyOf(includeUrls);
+	}
+
+	public void setExcludeUrls(Collection<AntPathRequestMatcher> excludeUrls) {
+		Assert.notNull(excludeUrls, "excludeUrls is required; it must not be null");
+		this.excludeUrls = List.copyOf(excludeUrls);
+	}
+
+	public boolean shouldPersist(HttpTrace httpTrace) {
+		return isIncluded(httpTrace) && isNotExcluded(httpTrace);
 	}
 
 	@Mapper

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -182,6 +182,11 @@ application:
       template-id: 5768860b-6953-4e41-9f56-4e508f4fa9f3
   http-request-repository:
     page-size: 100                    # number of http request/response trace requests to return from /actuator/httptrace
+    includeUrls:                      # list of URLs to include, in ant path style
+      - /**
+    excludeUrls:                      # list of URLs to exclude, in ant path style
+      - /actuator/health/liveness
+      - /actuator/health/readiness
   jms:
     destination:
       passport-status: passport-statuses


### PR DESCRIPTION
Add http request repository filtering pattern like `RequestLoggingFilter` but it's only applied to persistence DB repository not for in-memory http trace.

[ADO-1293](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1293)