### PR TITLE
Updated char limit from 32 to 50 on manifest number field

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentificationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentificationModel.java
@@ -35,7 +35,7 @@ public interface CertificateApplicationIdentificationModel extends Serializable 
 	String getIdentificationCategoryText();
 
 	@JsonProperty("IdentificationID")
-	@Size(max = 32, message = "IdentificationID must be 32 characters or less")
+	@Size(max = 50, message = "IdentificationID must be 50 characters or less")
 	@Schema(description = "The value of the certificate application ID entry.", example = "ABCD1234")
 	String getIdentificationId();
 

--- a/src/main/resources/db-migrations/common/v0-[common]-schema-init.sql
+++ b/src/main/resources/db-migrations/common/v0-[common]-schema-init.sql
@@ -91,7 +91,7 @@ CREATE TABLE passport_status
 	email VARCHAR(256),
 	file_number VARCHAR(32) NOT NULL,
 	given_name VARCHAR(128) NOT NULL,
-	manifest_number VARCHAR(32),
+	manifest_number VARCHAR(50),
 	surname VARCHAR(128) NOT NULL,
 	status_code_id VARCHAR(64) NOT NULL,
 	status_date DATE NOT NULL,


### PR DESCRIPTION
update our character limit on the manifest number field to match IRCC at 50 characters.