### PR TITLE
Fix error Cannot build NotificationSentEvent

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/web/ElectronicServiceRequestController.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/ElectronicServiceRequestController.java
@@ -103,7 +103,7 @@ public class ElectronicServiceRequestController {
 					.fileNumber(passportStatus.getFileNumber())
 					.givenName(passportStatus.getGivenName())
 					.preferredLanguage(preferredLanguage)
-					.givenName(passportStatus.getSurname())
+					.surname(passportStatus.getSurname())
 					.build());
 			},
 			() -> eventPublisher.publishEvent(NotificationNotSentEvent.builder()


### PR DESCRIPTION
Fix error: Cannot build NotificationSentEvent, some of required attributes are not set [surname]

```bash
java.lang.IllegalStateException: Cannot build NotificationSentEvent, some of required attributes are not set [surname]
	at ca.gov.dtsstn.passport.api.event.ImmutableNotificationSentEvent$Builder.build(ImmutableNotificationSentEvent.java:396) ~[classes/:na]
ImmutableNotificationSentEvent.java:396
	at ca.gov.dtsstn.passport.api.web.ElectronicServiceRequestController.lambda$0(ElectronicServiceRequestController.java:107) ~[classes/:na]
ElectronicServiceRequestController.java:107
	at java.base/java.util.Optional.ifPresentOrElse(Optional.java:196) ~[na:na]
Optional.java:196
	at ca.gov.dtsstn.passport.api.web.ElectronicServiceRequestController.create(ElectronicServiceRequestController.java:97) ~[classes/:na]
	...
```