### PR TITLE
Add explicit schema name to unaccent function in remove_diacritics

### DIFF
--- a/src/main/resources/db-migrations/postgresql/v0.1-[vendor]-schema-init.sql
+++ b/src/main/resources/db-migrations/postgresql/v0.1-[vendor]-schema-init.sql
@@ -5,7 +5,7 @@ CREATE FUNCTION remove_diacritics(text)
   LANGUAGE sql
   IMMUTABLE PARALLEL SAFE STRICT
 AS $func$
-SELECT unaccent($1)
+SELECT public.unaccent($1)
 $func$;
 
 CREATE FUNCTION remove_non_alpha_numeric(text)


### PR DESCRIPTION
This change was manually applied to all running environments including production.