### PR TITLE
Patched snakeyml to 1.33 instead of managed 1.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		<icu4j.version>72.1</icu4j.version>
 		<immutables.version>2.9.3</immutables.version>
 		<mapstruct.version>1.5.3.Final</mapstruct.version>
+		<snakeyaml.version>1.33</snakeyaml.version>
 		<spring-boot-configuration-processor.version>2.7.4</spring-boot-configuration-processor.version>
 		<springdoc.version>1.6.14</springdoc.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<icu4j.version>72.1</icu4j.version>
 		<immutables.version>2.9.3</immutables.version>
 		<mapstruct.version>1.5.3.Final</mapstruct.version>
-		<snakeyaml.version>1.33</snakeyaml.version>
+		<snakeyaml.version>1.33</snakeyaml.version><!-- TODO remove when upgrading to Spring Boot 3.x -->
 		<spring-boot-configuration-processor.version>2.7.4</spring-boot-configuration-processor.version>
 		<springdoc.version>1.6.14</springdoc.version>
 	</properties>


### PR DESCRIPTION
Datafaker 1.7.0 pulls in 1.33, but spring managed versions overwrites it to 1.30 which has some vulnerabilities. So we need to force it to use the proper patched version.