### PR TITLE
Added event logging to std out, removed uneccessary controller endpoints

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/event/listener/NotificationEventListener.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/listener/NotificationEventListener.java
@@ -1,5 +1,7 @@
 package ca.gov.dtsstn.passport.api.event.listener;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -21,6 +23,7 @@ import ca.gov.dtsstn.passport.api.event.NotificationSentEvent;
  */
 @Component
 public class NotificationEventListener {
+	private final Logger log = LoggerFactory.getLogger(NotificationEventListener.class);
 
 	private final EventLogRepository eventLogRepository;
 
@@ -31,38 +34,44 @@ public class NotificationEventListener {
 		this.eventLogRepository = eventLogRepository;
 
 		this.objectMapper = new ObjectMapper()
-			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-			.findAndRegisterModules();
+				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+				.findAndRegisterModules();
 	}
 
 	@Async
 	@EventListener({ NotificationNotSentEvent.class })
 	public void handleNotificationNotSentEvent(NotificationNotSentEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.GET_ESRF_FAIL)
-			.description("ESRF notification failure")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.GET_ESRF_FAIL)
+				.description("ESRF notification failure")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: Get ESRF fail");
 	}
 
 	@Async
 	@EventListener({ NotificationRequestedEvent.class })
 	public void handleNotificationRequestedEvent(NotificationRequestedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.GET_ESRF_REQUEST)
-			.description("ESRF notification requested")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.GET_ESRF_REQUEST)
+				.description("ESRF notification requested")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: ESRF notification requested");
 	}
 
 	@Async
 	@EventListener({ NotificationSentEvent.class })
 	public void handleNotificationSentEvent(NotificationSentEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.GET_ESRF_SUCCESS)
-			.description("ESRF notification success")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.GET_ESRF_SUCCESS)
+				.description("ESRF notification success")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: ESRF notification success");
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/event/listener/NotificationEventListener.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/listener/NotificationEventListener.java
@@ -23,7 +23,7 @@ import ca.gov.dtsstn.passport.api.event.NotificationSentEvent;
  */
 @Component
 public class NotificationEventListener {
-	private final Logger log = LoggerFactory.getLogger(NotificationEventListener.class);
+	private static final Logger log = LoggerFactory.getLogger(NotificationEventListener.class);
 
 	private final EventLogRepository eventLogRepository;
 
@@ -47,7 +47,7 @@ public class NotificationEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: Get ESRF fail");
+		log.info("Event: Get ESRF fail - " + event.getReason());
 	}
 
 	@Async
@@ -59,7 +59,7 @@ public class NotificationEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: ESRF notification requested");
+		log.info("Event: ESRF notification requested - " + event.getEmail());
 	}
 
 	@Async
@@ -71,7 +71,7 @@ public class NotificationEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: ESRF notification success");
+		log.info("Event: ESRF notification success - " + event.getEmail());
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/event/listener/NotificationEventListener.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/listener/NotificationEventListener.java
@@ -34,18 +34,18 @@ public class NotificationEventListener {
 		this.eventLogRepository = eventLogRepository;
 
 		this.objectMapper = new ObjectMapper()
-				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-				.findAndRegisterModules();
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.findAndRegisterModules();
 	}
 
 	@Async
 	@EventListener({ NotificationNotSentEvent.class })
 	public void handleNotificationNotSentEvent(NotificationNotSentEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.GET_ESRF_FAIL)
-				.description("ESRF notification failure")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.GET_ESRF_FAIL)
+			.description("ESRF notification failure")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: Get ESRF fail");
 	}
@@ -54,10 +54,10 @@ public class NotificationEventListener {
 	@EventListener({ NotificationRequestedEvent.class })
 	public void handleNotificationRequestedEvent(NotificationRequestedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.GET_ESRF_REQUEST)
-				.description("ESRF notification requested")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.GET_ESRF_REQUEST)
+			.description("ESRF notification requested")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: ESRF notification requested");
 	}
@@ -66,10 +66,10 @@ public class NotificationEventListener {
 	@EventListener({ NotificationSentEvent.class })
 	public void handleNotificationSentEvent(NotificationSentEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.GET_ESRF_SUCCESS)
-				.description("ESRF notification success")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.GET_ESRF_SUCCESS)
+			.description("ESRF notification success")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: ESRF notification success");
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/event/listener/PassportStatusEventListener.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/listener/PassportStatusEventListener.java
@@ -38,18 +38,18 @@ public class PassportStatusEventListener {
 		this.eventLogRepository = eventLogRepository;
 
 		this.objectMapper = new ObjectMapper()
-				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-				.findAndRegisterModules();
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.findAndRegisterModules();
 	}
 
 	@Async
 	@EventListener({ PassportStatusCreateConflictEvent.class })
 	public void handleCreated(PassportStatusCreateConflictEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.CREATE_STATUS_CONFLICT)
-				.description("Passport status create conflict")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.CREATE_STATUS_CONFLICT)
+			.description("Passport status create conflict")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: status create conflict");
 	}
@@ -58,10 +58,10 @@ public class PassportStatusEventListener {
 	@EventListener({ PassportStatusCreatedEvent.class })
 	public void handleCreated(PassportStatusCreatedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.CREATE_STATUS_SUCCESS)
-				.description("Passport status create success")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.CREATE_STATUS_SUCCESS)
+			.description("Passport status create success")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: status created");
 	}
@@ -70,10 +70,10 @@ public class PassportStatusEventListener {
 	@EventListener
 	public void handleRead(PassportStatusReadEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.READ_STATUS_SUCCESS)
-				.description("Passport status read success")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.READ_STATUS_SUCCESS)
+			.description("Passport status read success")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: status read");
 	}
@@ -82,10 +82,10 @@ public class PassportStatusEventListener {
 	@EventListener({ PassportStatusUpdatedEvent.class })
 	public void handleUpdated(PassportStatusUpdatedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.UPDATE_STATUS_SUCCESS)
-				.description("Passport status update success")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.UPDATE_STATUS_SUCCESS)
+			.description("Passport status update success")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		log.info("Event: status updated");
 	}
@@ -94,10 +94,10 @@ public class PassportStatusEventListener {
 	@EventListener({ PassportStatusDeletedEvent.class })
 	public void handleDeleted(PassportStatusDeletedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.DELETE_STATUS_SUCCESS)
-				.description("Passport status delete success")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+			.eventType(EventLogType.DELETE_STATUS_SUCCESS)
+			.description("Passport status delete success")
+			.details(objectMapper.writeValueAsString(event))
+			.build());
 
 		// Setting this as warning, since deletion should only be happening as part of
 		// our retention policy so if this pops up unexpectedly we don't want to lose it
@@ -110,22 +110,22 @@ public class PassportStatusEventListener {
 	public void handleSearch(PassportStatusSearchEvent event) throws JsonProcessingException {
 		switch (event.getResult()) {
 			case HIT -> eventLogRepository.save(new EventLogEntityBuilder()
-					.eventType(EventLogType.SEARCH_STATUS_HIT)
-					.description("Passport status search hit")
-					.details(objectMapper.writeValueAsString(event))
-					.build());
+				.eventType(EventLogType.SEARCH_STATUS_HIT)
+				.description("Passport status search hit")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
 
 			case MISS -> eventLogRepository.save(new EventLogEntityBuilder()
-					.eventType(EventLogType.SEARCH_STATUS_MISS)
-					.description("Passport status search miss")
-					.details(objectMapper.writeValueAsString(event))
-					.build());
+				.eventType(EventLogType.SEARCH_STATUS_MISS)
+				.description("Passport status search miss")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
 
 			case NON_UNIQUE -> eventLogRepository.save(new EventLogEntityBuilder()
-					.eventType(EventLogType.SEARCH_STATUS_NON_UNIQUE)
-					.description("Passport status search non-unique")
-					.details(objectMapper.writeValueAsString(event))
-					.build());
+				.eventType(EventLogType.SEARCH_STATUS_NON_UNIQUE)
+				.description("Passport status search non-unique")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
 
 			default -> log.warn("PassportStatusSearchEvent {} result is not implemented", event.getResult());
 		}

--- a/src/main/java/ca/gov/dtsstn/passport/api/event/listener/PassportStatusEventListener.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/listener/PassportStatusEventListener.java
@@ -51,7 +51,7 @@ public class PassportStatusEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: status create conflict");
+		log.info("Event: status create conflict - ID: " + event.getEntity().getId());
 	}
 
 	@Async
@@ -63,7 +63,7 @@ public class PassportStatusEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: status created");
+		log.info("Event: status created - ID: " + event.getEntity().getId());
 	}
 
 	@Async
@@ -75,7 +75,7 @@ public class PassportStatusEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: status read");
+		log.info("Event: status read - ID: " + event.getEntity().getId());
 	}
 
 	@Async
@@ -87,7 +87,7 @@ public class PassportStatusEventListener {
 			.details(objectMapper.writeValueAsString(event))
 			.build());
 
-		log.info("Event: status updated");
+		log.info("Event: status updated - Updated ID: " + event.getUpdatedEntity().getId());
 	}
 
 	@Async
@@ -102,7 +102,7 @@ public class PassportStatusEventListener {
 		// Setting this as warning, since deletion should only be happening as part of
 		// our retention policy so if this pops up unexpectedly we don't want to lose it
 		// in the noise.
-		log.warn("Event: status deleted");
+		log.warn("Event: status deleted - ID: " + event.getEntity().getId());
 	}
 
 	@Async
@@ -130,7 +130,7 @@ public class PassportStatusEventListener {
 			default -> log.warn("PassportStatusSearchEvent {} result is not implemented", event.getResult());
 		}
 
-		log.info("Event: Search result - " + event.getResult().toString());
+		log.info("Event: Search result - Result: " + event.getResult().toString());
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/event/listener/PassportStatusEventListener.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/listener/PassportStatusEventListener.java
@@ -38,84 +38,99 @@ public class PassportStatusEventListener {
 		this.eventLogRepository = eventLogRepository;
 
 		this.objectMapper = new ObjectMapper()
-			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-			.findAndRegisterModules();
+				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+				.findAndRegisterModules();
 	}
 
 	@Async
 	@EventListener({ PassportStatusCreateConflictEvent.class })
 	public void handleCreated(PassportStatusCreateConflictEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.CREATE_STATUS_CONFLICT)
-			.description("Passport status create conflict")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.CREATE_STATUS_CONFLICT)
+				.description("Passport status create conflict")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: status create conflict");
 	}
 
 	@Async
 	@EventListener({ PassportStatusCreatedEvent.class })
 	public void handleCreated(PassportStatusCreatedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.CREATE_STATUS_SUCCESS)
-			.description("Passport status create success")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.CREATE_STATUS_SUCCESS)
+				.description("Passport status create success")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: status created");
 	}
 
 	@Async
 	@EventListener
 	public void handleRead(PassportStatusReadEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.READ_STATUS_SUCCESS)
-			.description("Passport status read success")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.READ_STATUS_SUCCESS)
+				.description("Passport status read success")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: status read");
 	}
 
 	@Async
 	@EventListener({ PassportStatusUpdatedEvent.class })
 	public void handleUpdated(PassportStatusUpdatedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.UPDATE_STATUS_SUCCESS)
-			.description("Passport status update success")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.UPDATE_STATUS_SUCCESS)
+				.description("Passport status update success")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		log.info("Event: status updated");
 	}
 
 	@Async
 	@EventListener({ PassportStatusDeletedEvent.class })
 	public void handleDeleted(PassportStatusDeletedEvent event) throws JsonProcessingException {
 		eventLogRepository.save(new EventLogEntityBuilder()
-			.eventType(EventLogType.DELETE_STATUS_SUCCESS)
-			.description("Passport status delete success")
-			.details(objectMapper.writeValueAsString(event))
-			.build());
+				.eventType(EventLogType.DELETE_STATUS_SUCCESS)
+				.description("Passport status delete success")
+				.details(objectMapper.writeValueAsString(event))
+				.build());
+
+		// Setting this as warning, since deletion should only be happening as part of
+		// our retention policy so if this pops up unexpectedly we don't want to lose it
+		// in the noise.
+		log.warn("Event: status deleted");
 	}
 
 	@Async
 	@EventListener({ PassportStatusSearchEvent.class })
 	public void handleSearch(PassportStatusSearchEvent event) throws JsonProcessingException {
-		switch(event.getResult()){
+		switch (event.getResult()) {
 			case HIT -> eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.SEARCH_STATUS_HIT)
-				.description("Passport status search hit")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+					.eventType(EventLogType.SEARCH_STATUS_HIT)
+					.description("Passport status search hit")
+					.details(objectMapper.writeValueAsString(event))
+					.build());
 
 			case MISS -> eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.SEARCH_STATUS_MISS)
-				.description("Passport status search miss")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+					.eventType(EventLogType.SEARCH_STATUS_MISS)
+					.description("Passport status search miss")
+					.details(objectMapper.writeValueAsString(event))
+					.build());
 
 			case NON_UNIQUE -> eventLogRepository.save(new EventLogEntityBuilder()
-				.eventType(EventLogType.SEARCH_STATUS_NON_UNIQUE)
-				.description("Passport status search non-unique")
-				.details(objectMapper.writeValueAsString(event))
-				.build());
+					.eventType(EventLogType.SEARCH_STATUS_NON_UNIQUE)
+					.description("Passport status search non-unique")
+					.details(objectMapper.writeValueAsString(event))
+					.build());
 
-			default ->  log.warn("PassportStatusSearchEvent {} result is not implemented", event.getResult());
+			default -> log.warn("PassportStatusSearchEvent {} result is not implemented", event.getResult());
 		}
+
+		log.info("Event: Search result - " + event.getResult().toString());
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
@@ -68,18 +68,17 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 		log.error("Authentication Error: Code = 401, Remote Address = " + request.getRemoteAddr());
 
 		final var body = ImmutableErrorResponseModel.builder()
-				.operationOutcome(ImmutableOperationOutcomeModel.builder()
-						.addIssues(ImmutableIssueModel.builder()
-								.issueCode("API-0401")
-								.issueDetails(
-										"The request lacks valid authentication credentials for the requested resource.")
-								.build())
-						.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
-								.statusCode("401")
-								.statusDescriptionText("Unauthorized")
-								.build())
-						.build())
-				.build();
+			.operationOutcome(ImmutableOperationOutcomeModel.builder()
+				.addIssues(ImmutableIssueModel.builder()
+					.issueCode("API-0401")
+					.issueDetails("The request lacks valid authentication credentials for the requested resource.")
+					.build())
+				.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
+					.statusCode("401")
+					.statusDescriptionText("Unauthorized")
+					.build())
+				.build())
+			.build();
 
 		sendResponse(response, HttpStatus.UNAUTHORIZED, body);
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
@@ -35,11 +35,15 @@ import ca.gov.dtsstn.passport.api.web.model.ImmutableOperationOutcomeStatusModel
 
 /**
  * This class functions as both a {@code RestControllerAdvice}, as well as a
- * Spring Security {@code AccessDeniedHandler} and {@code AuthenticationEntryPoint}.
+ * Spring Security {@code AccessDeniedHandler} and
+ * {@code AuthenticationEntryPoint}.
  * <p>
- * The reason for the dual-responsibility is because of how Spring Security handles rules configured in its
- * {@code SecurityFilterChain} vs {@code @PreAuthorize} annotated methods. The former are handled as
- * {@code AccessDeniedHandler} and {@code AuthenticationEntryPoint}, the latter as an {@code @ExceptionHandler}.
+ * The reason for the dual-responsibility is because of how Spring Security
+ * handles rules configured in its
+ * {@code SecurityFilterChain} vs {@code @PreAuthorize} annotated methods. The
+ * former are handled as
+ * {@code AccessDeniedHandler} and {@code AuthenticationEntryPoint}, the latter
+ * as an {@code @ExceptionHandler}.
  *
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
  */
@@ -58,45 +62,62 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 
 	@Override
 	@ExceptionHandler({ AuthenticationException.class })
-	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException {
+
+		// The only authentication we have is from Interop, so this is a canary log
+		// statement for our analytics teams, where if this happens and the IP isn't on
+		// our expected subnet we'll know something's going wrong within the VNET or
+		// wider hub/spoke.
+		log.error("Authentication Error: Code = 401, Remote Address = " + request.getRemoteAddr());
+
 		final var body = ImmutableErrorResponseModel.builder()
-			.operationOutcome(ImmutableOperationOutcomeModel.builder()
-				.addIssues(ImmutableIssueModel.builder()
-					.issueCode("API-0401")
-					.issueDetails("The request lacks valid authentication credentials for the requested resource.")
-					.build())
-				.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
-					.statusCode("401")
-					.statusDescriptionText("Unauthorized")
-					.build())
-				.build())
-			.build();
+				.operationOutcome(ImmutableOperationOutcomeModel.builder()
+						.addIssues(ImmutableIssueModel.builder()
+								.issueCode("API-0401")
+								.issueDetails(
+										"The request lacks valid authentication credentials for the requested resource.")
+								.build())
+						.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
+								.statusCode("401")
+								.statusDescriptionText("Unauthorized")
+								.build())
+						.build())
+				.build();
 
 		sendResponse(response, HttpStatus.UNAUTHORIZED, body);
 	}
 
 	@Override
 	@ExceptionHandler({ AccessDeniedException.class })
-	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+			AccessDeniedException accessDeniedException) throws IOException {
 		if (isAnonymous()) {
 			// Spring Security has this odd quirk whereby it will not throw an
-			// AuthenticationCredentialsNotFoundException if the current user is an anonymous user. 🤷
+			// AuthenticationCredentialsNotFoundException if the current user is an
+			// anonymous user. 🤷
 			// see: AbstractSecurityInterceptor.beforeInvocation(..) for reference
 			throw new AuthenticationCredentialsNotFoundException(accessDeniedException.getMessage());
 		}
 
+		// The only authentication we have is from Interop, so this is a canary log
+		// statement for our analytics teams, where if this happens and the IP isn't on
+		// our expected subnet we'll know something's going wrong within the VNET or
+		// wider hub/spoke.
+		log.error("Authentication Error: Code = 403, Remote Address = " + request.getRemoteAddr());
+
 		final var body = ImmutableErrorResponseModel.builder()
-			.operationOutcome(ImmutableOperationOutcomeModel.builder()
-				.addIssues(ImmutableIssueModel.builder()
-					.issueCode("API-0403")
-					.issueDetails("The server understands the request but refuses to authorize it.")
-					.build())
-				.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
-					.statusCode("403")
-					.statusDescriptionText("Forbidden")
-					.build())
-				.build())
-			.build();
+				.operationOutcome(ImmutableOperationOutcomeModel.builder()
+						.addIssues(ImmutableIssueModel.builder()
+								.issueCode("API-0403")
+								.issueDetails("The server understands the request but refuses to authorize it.")
+								.build())
+						.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
+								.statusCode("403")
+								.statusDescriptionText("Forbidden")
+								.build())
+						.build())
+				.build();
 
 		sendResponse(response, HttpStatus.FORBIDDEN, body);
 	}
@@ -114,8 +135,8 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 
 	protected boolean isAnonymous() {
 		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-			.map(Authentication::getAuthorities).orElse(Collections.emptyList()).stream()
-			.map(GrantedAuthority::getAuthority).anyMatch("ROLE_ANONYMOUS"::equals);
+				.map(Authentication::getAuthorities).orElse(Collections.emptyList()).stream()
+				.map(GrantedAuthority::getAuthority).anyMatch("ROLE_ANONYMOUS"::equals);
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
@@ -35,15 +35,11 @@ import ca.gov.dtsstn.passport.api.web.model.ImmutableOperationOutcomeStatusModel
 
 /**
  * This class functions as both a {@code RestControllerAdvice}, as well as a
- * Spring Security {@code AccessDeniedHandler} and
- * {@code AuthenticationEntryPoint}.
+ * Spring Security {@code AccessDeniedHandler} and {@code AuthenticationEntryPoint}.
  * <p>
- * The reason for the dual-responsibility is because of how Spring Security
- * handles rules configured in its
- * {@code SecurityFilterChain} vs {@code @PreAuthorize} annotated methods. The
- * former are handled as
- * {@code AccessDeniedHandler} and {@code AuthenticationEntryPoint}, the latter
- * as an {@code @ExceptionHandler}.
+ * The reason for the dual-responsibility is because of how Spring Security handles rules configured in its
+ * {@code SecurityFilterChain} vs {@code @PreAuthorize} annotated methods. The former are handled as
+ * {@code AccessDeniedHandler} and {@code AuthenticationEntryPoint}, the latter as an {@code @ExceptionHandler}.
  *
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
  */
@@ -94,8 +90,7 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 			AccessDeniedException accessDeniedException) throws IOException {
 		if (isAnonymous()) {
 			// Spring Security has this odd quirk whereby it will not throw an
-			// AuthenticationCredentialsNotFoundException if the current user is an
-			// anonymous user. 🤷
+			// AuthenticationCredentialsNotFoundException if the current user is an anonymous user. 🤷
 			// see: AbstractSecurityInterceptor.beforeInvocation(..) for reference
 			throw new AuthenticationCredentialsNotFoundException(accessDeniedException.getMessage());
 		}
@@ -107,17 +102,17 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 		log.error("Authentication Error: Code = 403, Remote Address = " + request.getRemoteAddr());
 
 		final var body = ImmutableErrorResponseModel.builder()
-				.operationOutcome(ImmutableOperationOutcomeModel.builder()
-						.addIssues(ImmutableIssueModel.builder()
-								.issueCode("API-0403")
-								.issueDetails("The server understands the request but refuses to authorize it.")
-								.build())
-						.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
-								.statusCode("403")
-								.statusDescriptionText("Forbidden")
-								.build())
-						.build())
-				.build();
+			.operationOutcome(ImmutableOperationOutcomeModel.builder()
+				.addIssues(ImmutableIssueModel.builder()
+					.issueCode("API-0403")
+					.issueDetails("The server understands the request but refuses to authorize it.")
+					.build())
+				.operationOutcomeStatus(ImmutableOperationOutcomeStatusModel.builder()
+					.statusCode("403")
+					.statusDescriptionText("Forbidden")
+					.build())
+				.build())
+			.build();
 
 		sendResponse(response, HttpStatus.FORBIDDEN, body);
 	}
@@ -135,8 +130,8 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 
 	protected boolean isAnonymous() {
 		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-				.map(Authentication::getAuthorities).orElse(Collections.emptyList()).stream()
-				.map(GrantedAuthority::getAuthority).anyMatch("ROLE_ANONYMOUS"::equals);
+			.map(Authentication::getAuthorities).orElse(Collections.emptyList()).stream()
+			.map(GrantedAuthority::getAuthority).anyMatch("ROLE_ANONYMOUS"::equals);
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
@@ -65,7 +65,7 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 		// statement for our analytics teams, where if this happens and the IP isn't on
 		// our expected subnet we'll know something's going wrong within the VNET or
 		// wider hub/spoke.
-		log.error("Authentication Error: Code = 401, Remote Address = " + request.getRemoteAddr());
+		log.warn("Authentication Error: Code = 401, Remote Address = " + request.getRemoteAddr());
 
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
@@ -98,7 +98,7 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 		// statement for our analytics teams, where if this happens and the IP isn't on
 		// our expected subnet we'll know something's going wrong within the VNET or
 		// wider hub/spoke.
-		log.error("Authentication Error: Code = 403, Remote Address = " + request.getRemoteAddr());
+		log.warn("Authentication Error: Code = 403, Remote Address = " + request.getRemoteAddr());
 
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/PassportStatusController.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/PassportStatusController.java
@@ -104,10 +104,8 @@ public class PassportStatusController {
 	/**
 	 * Create a new {@link PassportStatus} in the system.
 	 *
-	 * TODO :: GjB :: in some rare cases, a status of {@code INVALID} for a specific
-	 * {@code applicationRegisterSid} can be sent..
-	 * TODO :: GjB :: in these cases, we must relax validation and allow the invalid
-	 * passport status to be stored 😒
+	 * TODO :: GjB :: in some rare cases, a status of {@code INVALID} for a specific {@code applicationRegisterSid} can be sent..
+	 * TODO :: GjB :: in these cases, we must relax validation and allow the invalid passport status to be stored 😒
 	 */
 	@PostMapping({ "" })
 	@ApiResponses.BadRequestError
@@ -120,22 +118,22 @@ public class PassportStatusController {
 	@Operation(summary = "Create a new passport status.", operationId = "passport-status-create")
 	@ApiResponse(responseCode = "202", description = "The request has been accepted for processing.")
 	public void create(
-			@RequestBody(required = true) CreateCertificateApplicationRequestModel createCertificateApplicationRequest,
+			@RequestBody(required = true)
+			CreateCertificateApplicationRequestModel createCertificateApplicationRequest,
 
-			@RequestParam(defaultValue = "true", required = false) @BooleanString(message = "async must be one of: 'true', 'false'") @Parameter(description = "If the request should be handled asynchronously.", schema = @Schema(allowableValues = {
-					"false", "true" }, defaultValue = "true")) String async) {
+			@RequestParam(defaultValue = "true", required = false)
+			@BooleanString(message = "async must be one of: 'true', 'false'")
+			@Parameter(description = "If the request should be handled asynchronously.", schema = @Schema(allowableValues = { "false", "true" }, defaultValue = "true"))
+			String async) {
 		if (!BooleanUtils.toBoolean(async)) {
 			log.warn("Call to unsupported operation: create(async=false)");
-			throw new UnsupportedOperationException(
-					"synchronous processing not yet implemented; please set async=true");
+			throw new UnsupportedOperationException("synchronous processing not yet implemented; please set async=true");
 		}
 
 		// TODO :: GjB :: relax validation if status=INVALID
 		log.debug("Performing field validations on createCertificateApplicationRequest");
 		final var constraintViolations = validator.validate(createCertificateApplicationRequest);
-		if (!constraintViolations.isEmpty()) {
-			throw new ConstraintViolationException(constraintViolations);
-		}
+		if (!constraintViolations.isEmpty()) { throw new ConstraintViolationException(constraintViolations); }
 		log.debug("createCertificateApplicationRequest passed validation with no errors");
 
 		final var passportStatus = mapper.toDomain(createCertificateApplicationRequest);
@@ -147,24 +145,20 @@ public class PassportStatusController {
 	 * Perform a passport status search using the following fields:
 	 *
 	 * <ul>
-	 * <li>{@code dateOfBirth}
-	 * <li>{@code fileNumber}
-	 * <li>{@code givenName}
-	 * <li>{@code surname}
+	 *   <li>{@code dateOfBirth}
+	 *   <li>{@code fileNumber}
+	 *   <li>{@code givenName}
+	 *   <li>{@code surname}
 	 *
 	 * This endpoint will perform some logic on the search results as follows:
 	 *
 	 * <ol>
-	 * <li>Perform a search using the provided parameters
-	 * <li>Check for distinct {@code applicationRegisterSid}; throw exception if
-	 * <strong>more than one</strong> value is found
-	 * <li>If a distict {@code applicationRegisterSid} was found, perform a new
-	 * search using the {@code applicationRegisterSid}
-	 * <li>Sort the results by {@code PassportStatus.version}, extract newest
-	 * passport status, wrap in a collection and return
+	 *   <li>Perform a search using the provided parameters
+	 *   <li>Check for distinct {@code applicationRegisterSid}; throw exception if <strong>more than one</strong> value is found
+	 *   <li>If a distict {@code applicationRegisterSid} was found, perform a new search using the {@code applicationRegisterSid}
+	 *   <li>Sort the results by {@code PassportStatus.version}, extract newest passport status, wrap in a collection and return
 	 *
-	 * TODO :: GjB :: in some rare cases, a passport status may enter an
-	 * {@code INVALID} state. We must handle this state appropriately.
+	 * TODO :: GjB :: in some rare cases, a passport status may enter an {@code INVALID} state. We must handle this state appropriately.
 	 */
 	@GetMapping({ "/_search" })
 	@ApiResponses.BadRequestError
@@ -173,41 +167,46 @@ public class PassportStatusController {
 	@ApiResponse(responseCode = "200", description = "Retrieve a paged list of all passport statuses satisfying the search criteria.")
 	@Operation(summary = "Search for a passport status by fileNumber, givenName, surname and dateOfBirth.", operationId = "passport-status-search")
 	public CollectionModel<GetCertificateApplicationRepresentationModel> search(
-			@DateTimeFormat(iso = ISO.DATE) @NotNull(message = "dateOfBirth must not be null or blank") @PastOrPresent(message = "dateOfBirth must be a date in the past") @Parameter(description = "The date of birth of the passport applicant in ISO-8601 format.", example = "2000-01-01", required = true) @RequestParam(required = false) LocalDate dateOfBirth,
+			@DateTimeFormat(iso = ISO.DATE)
+			@NotNull(message = "dateOfBirth must not be null or blank")
+			@PastOrPresent(message = "dateOfBirth must be a date in the past")
+			@Parameter(description = "The date of birth of the passport applicant in ISO-8601 format.", example = "2000-01-01", required = true)
+			@RequestParam(required = false) LocalDate dateOfBirth,
 
-			@NotBlank(message = "fileNumber must not be null or blank") @Parameter(description = "The electronic service request file number.", example = "ABCD1234", required = true) @RequestParam(required = false) String fileNumber,
+			@NotBlank(message = "fileNumber must not be null or blank")
+			@Parameter(description = "The electronic service request file number.", example = "ABCD1234", required = true)
+			@RequestParam(required = false) String fileNumber,
 
-			@NotBlank(message = "givenName must not be null or blank") @Parameter(description = "The given name of the passport applicant.", example = "John", required = true) @RequestParam(required = false) String givenName,
+			@NotBlank(message = "givenName must not be null or blank")
+			@Parameter(description = "The given name of the passport applicant.", example = "John", required = true)
+			@RequestParam(required = false) String givenName,
 
-			@NotBlank(message = "surname must not be null or blank") @Parameter(description = "The surname of the passport applicant.", example = "Doe", required = true) @RequestParam(required = false) String surname,
+			@NotBlank(message = "surname must not be null or blank")
+			@Parameter(description = "The surname of the passport applicant.", example = "Doe", required = true)
+			@RequestParam(required = false) String surname,
 
 			@Deprecated // This parameter will soon be removed
-			@Parameter(description = "If the query should return a single unique result.", required = false) @RequestParam(defaultValue = "true") boolean unique) {
-		log.debug("Performing passport status search using terms {}",
-				List.of(dateOfBirth, fileNumber, givenName, surname));
+			@Parameter(description = "If the query should return a single unique result.", required = false)
+			@RequestParam(defaultValue = "true") boolean unique) {
+		log.debug("Performing passport status search using terms {}", List.of(dateOfBirth, fileNumber, givenName, surname));
 		final var initialSearchResults = service.fileNumberSearch(dateOfBirth, fileNumber, givenName, surname);
-		log.debug("{} results returned for search terms {}", initialSearchResults.size(),
-				List.of(dateOfBirth, fileNumber, givenName, surname));
+		log.debug("{} results returned for search terms {}", initialSearchResults.size(), List.of(dateOfBirth, fileNumber, givenName, surname));
 
 		log.debug("Checking results for distinct applicationRegisterSids");
-		final var applicationRegisterSids = initialSearchResults.stream().map(PassportStatus::getApplicationRegisterSid)
-				.distinct().toList();
+		final var applicationRegisterSids = initialSearchResults.stream().map(PassportStatus::getApplicationRegisterSid).distinct().toList();
 		final var nApplicationRegisterSids = applicationRegisterSids.size();
 		log.debug("Number of distinct applicationRegisterSids: {}", nApplicationRegisterSids);
 
-		final var searchEventBuilder = PassportStatusSearchEvent.builder().dateOfBirth(dateOfBirth)
-				.fileNumber(fileNumber).givenName(givenName).surname(surname);
+		final var searchEventBuilder = PassportStatusSearchEvent.builder().dateOfBirth(dateOfBirth).fileNumber(fileNumber).givenName(givenName).surname(surname);
 
 		if (nApplicationRegisterSids > 1) {
-			log.warn("Search query returned non-unique applicationRegisterSid result: {}",
-					List.of(dateOfBirth, fileNumber, givenName, surname));
+			log.warn("Search query returned non-unique applicationRegisterSid result: {}", List.of(dateOfBirth, fileNumber, givenName, surname));
 			eventPublisher.publishEvent(searchEventBuilder.result(Result.NON_UNIQUE).build());
 			throw new NonUniqueResourceException("Search query returned non-unique applicationRegisterSid result");
 		}
 
 		log.debug("Performing applicationRegisterSid search");
-		final var passportStatuses = applicationRegisterSids.stream().findFirst()
-				.map(service::applicationRegisterSidSearch).orElse(Collections.emptyList());
+		final var passportStatuses = applicationRegisterSids.stream().findFirst().map(service::applicationRegisterSidSearch).orElse(Collections.emptyList());
 		final var passportStatus = passportStatuses.stream().sorted(byVersionDesc()).findFirst();
 		log.debug("applicationRegisterSid search produced {} results", passportStatuses.size());
 
@@ -215,13 +214,10 @@ public class PassportStatusController {
 		 * TODO :: GjB :: handle INVALID status by throwing exception here
 		 */
 
-		eventPublisher
-				.publishEvent(searchEventBuilder.result(passportStatuses.isEmpty() ? Result.MISS : Result.HIT).build());
+		eventPublisher.publishEvent(searchEventBuilder.result(passportStatuses.isEmpty() ? Result.MISS : Result.HIT).build());
 
-		final var selfLink = linkTo(methodOn(getClass()).search(dateOfBirth, fileNumber, givenName, surname, unique))
-				.withSelfRel();
-		final var collection = assembler.toCollectionModel(passportStatus.map(List::of).orElse(Collections.emptyList()))
-				.add(selfLink);
+		final var selfLink = linkTo(methodOn(getClass()).search(dateOfBirth, fileNumber, givenName, surname, unique)).withSelfRel();
+		final var collection = assembler.toCollectionModel(passportStatus.map(List::of).orElse(Collections.emptyList())).add(selfLink);
 		return assembler.wrapCollection(collection, GetCertificateApplicationRepresentationModel.class);
 	}
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/PassportStatusController.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/PassportStatusController.java
@@ -16,21 +16,15 @@ import javax.validation.constraints.PastOrPresent;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.SortDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
 import org.springframework.util.Assert;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,7 +40,6 @@ import ca.gov.dtsstn.passport.api.service.PassportStatusService;
 import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 import ca.gov.dtsstn.passport.api.web.annotation.Authorities;
 import ca.gov.dtsstn.passport.api.web.exception.NonUniqueResourceException;
-import ca.gov.dtsstn.passport.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.passport.api.web.model.CreateCertificateApplicationRequestModel;
 import ca.gov.dtsstn.passport.api.web.model.GetCertificateApplicationRepresentationModel;
 import ca.gov.dtsstn.passport.api.web.model.assembler.GetCertificateApplicationRepresentationModelAssembler;
@@ -111,8 +104,10 @@ public class PassportStatusController {
 	/**
 	 * Create a new {@link PassportStatus} in the system.
 	 *
-	 * TODO :: GjB :: in some rare cases, a status of {@code INVALID} for a specific {@code applicationRegisterSid} can be sent..
-	 * TODO :: GjB :: in these cases, we must relax validation and allow the invalid passport status to be stored 😒
+	 * TODO :: GjB :: in some rare cases, a status of {@code INVALID} for a specific
+	 * {@code applicationRegisterSid} can be sent..
+	 * TODO :: GjB :: in these cases, we must relax validation and allow the invalid
+	 * passport status to be stored 😒
 	 */
 	@PostMapping({ "" })
 	@ApiResponses.BadRequestError
@@ -125,22 +120,22 @@ public class PassportStatusController {
 	@Operation(summary = "Create a new passport status.", operationId = "passport-status-create")
 	@ApiResponse(responseCode = "202", description = "The request has been accepted for processing.")
 	public void create(
-			@RequestBody(required = true)
-			CreateCertificateApplicationRequestModel createCertificateApplicationRequest,
+			@RequestBody(required = true) CreateCertificateApplicationRequestModel createCertificateApplicationRequest,
 
-			@RequestParam(defaultValue = "true", required = false)
-			@BooleanString(message = "async must be one of: 'true', 'false'")
-			@Parameter(description = "If the request should be handled asynchronously.", schema = @Schema(allowableValues = { "false", "true" }, defaultValue = "true"))
-			String async) {
+			@RequestParam(defaultValue = "true", required = false) @BooleanString(message = "async must be one of: 'true', 'false'") @Parameter(description = "If the request should be handled asynchronously.", schema = @Schema(allowableValues = {
+					"false", "true" }, defaultValue = "true")) String async) {
 		if (!BooleanUtils.toBoolean(async)) {
 			log.warn("Call to unsupported operation: create(async=false)");
-			throw new UnsupportedOperationException("synchronous processing not yet implemented; please set async=true");
+			throw new UnsupportedOperationException(
+					"synchronous processing not yet implemented; please set async=true");
 		}
 
 		// TODO :: GjB :: relax validation if status=INVALID
 		log.debug("Performing field validations on createCertificateApplicationRequest");
 		final var constraintViolations = validator.validate(createCertificateApplicationRequest);
-		if (!constraintViolations.isEmpty()) { throw new ConstraintViolationException(constraintViolations); }
+		if (!constraintViolations.isEmpty()) {
+			throw new ConstraintViolationException(constraintViolations);
+		}
 		log.debug("createCertificateApplicationRequest passed validation with no errors");
 
 		final var passportStatus = mapper.toDomain(createCertificateApplicationRequest);
@@ -148,51 +143,28 @@ public class PassportStatusController {
 		passportStatusJmsService.send(passportStatus);
 	}
 
-	@GetMapping({ "/{id}" })
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses.AccessDeniedError
-	@ApiResponses.AuthenticationError
-	@ApiResponses.ResourceNotFoundError
-	@Authorities.HasPassportStatusRead
-	@SecurityRequirement(name = SpringDocConfig.HTTP)
-	@SecurityRequirement(name = SpringDocConfig.OAUTH)
-	@ApiResponse(responseCode = "200", description = "Returns an instance of a passport status.")
-	@Operation(summary = "Retrieves a passport status by its internal database ID.", operationId = "passport-status-read")
-	public GetCertificateApplicationRepresentationModel get(@Parameter(description = "The internal database ID that represents the passport status.") @PathVariable String id) {
-		return service.read(id).map(assembler::toModel).orElseThrow(() -> new ResourceNotFoundException("Could not find the passport status with id=[%s]".formatted(id)));
-	}
-
-	@GetMapping({ "" })
-	@ResponseStatus(HttpStatus.OK)
-	@ApiResponses.AccessDeniedError
-	@ApiResponses.AuthenticationError
-	@Authorities.HasPassportStatusReadAll
-	@SecurityRequirement(name = SpringDocConfig.HTTP)
-	@SecurityRequirement(name = SpringDocConfig.OAUTH)
-	@ApiResponse(responseCode = "200", description = "Retrieves all the passport statuses available to the user.")
-	@Operation(summary = "Retrieve a paged list of all passport statuses.", operationId = "passport-status-readall")
-	public PagedModel<GetCertificateApplicationRepresentationModel> getAll(Authentication authentication, @SortDefault({ "fileNumber" }) @ParameterObject Pageable pageable) {
-		return assembler.toModel(service.readAll(pageable));
-	}
-
 	/**
 	 * Perform a passport status search using the following fields:
 	 *
 	 * <ul>
-	 *   <li>{@code dateOfBirth}
-	 *   <li>{@code fileNumber}
-	 *   <li>{@code givenName}
-	 *   <li>{@code surname}
+	 * <li>{@code dateOfBirth}
+	 * <li>{@code fileNumber}
+	 * <li>{@code givenName}
+	 * <li>{@code surname}
 	 *
 	 * This endpoint will perform some logic on the search results as follows:
 	 *
 	 * <ol>
-	 *   <li>Perform a search using the provided parameters
-	 *   <li>Check for distinct {@code applicationRegisterSid}; throw exception if <strong>more than one</strong> value is found
-	 *   <li>If a distict {@code applicationRegisterSid} was found, perform a new search using the {@code applicationRegisterSid}
-	 *   <li>Sort the results by {@code PassportStatus.version}, extract newest passport status, wrap in a collection and return
+	 * <li>Perform a search using the provided parameters
+	 * <li>Check for distinct {@code applicationRegisterSid}; throw exception if
+	 * <strong>more than one</strong> value is found
+	 * <li>If a distict {@code applicationRegisterSid} was found, perform a new
+	 * search using the {@code applicationRegisterSid}
+	 * <li>Sort the results by {@code PassportStatus.version}, extract newest
+	 * passport status, wrap in a collection and return
 	 *
-	 * TODO :: GjB :: in some rare cases, a passport status may enter an {@code INVALID} state. We must handle this state appropriately.
+	 * TODO :: GjB :: in some rare cases, a passport status may enter an
+	 * {@code INVALID} state. We must handle this state appropriately.
 	 */
 	@GetMapping({ "/_search" })
 	@ApiResponses.BadRequestError
@@ -201,46 +173,41 @@ public class PassportStatusController {
 	@ApiResponse(responseCode = "200", description = "Retrieve a paged list of all passport statuses satisfying the search criteria.")
 	@Operation(summary = "Search for a passport status by fileNumber, givenName, surname and dateOfBirth.", operationId = "passport-status-search")
 	public CollectionModel<GetCertificateApplicationRepresentationModel> search(
-			@DateTimeFormat(iso = ISO.DATE)
-			@NotNull(message = "dateOfBirth must not be null or blank")
-			@PastOrPresent(message = "dateOfBirth must be a date in the past")
-			@Parameter(description = "The date of birth of the passport applicant in ISO-8601 format.", example = "2000-01-01", required = true)
-			@RequestParam(required = false) LocalDate dateOfBirth,
+			@DateTimeFormat(iso = ISO.DATE) @NotNull(message = "dateOfBirth must not be null or blank") @PastOrPresent(message = "dateOfBirth must be a date in the past") @Parameter(description = "The date of birth of the passport applicant in ISO-8601 format.", example = "2000-01-01", required = true) @RequestParam(required = false) LocalDate dateOfBirth,
 
-			@NotBlank(message = "fileNumber must not be null or blank")
-			@Parameter(description = "The electronic service request file number.", example = "ABCD1234", required = true)
-			@RequestParam(required = false) String fileNumber,
+			@NotBlank(message = "fileNumber must not be null or blank") @Parameter(description = "The electronic service request file number.", example = "ABCD1234", required = true) @RequestParam(required = false) String fileNumber,
 
-			@NotBlank(message = "givenName must not be null or blank")
-			@Parameter(description = "The given name of the passport applicant.", example = "John", required = true)
-			@RequestParam(required = false) String givenName,
+			@NotBlank(message = "givenName must not be null or blank") @Parameter(description = "The given name of the passport applicant.", example = "John", required = true) @RequestParam(required = false) String givenName,
 
-			@NotBlank(message = "surname must not be null or blank")
-			@Parameter(description = "The surname of the passport applicant.", example = "Doe", required = true)
-			@RequestParam(required = false) String surname,
+			@NotBlank(message = "surname must not be null or blank") @Parameter(description = "The surname of the passport applicant.", example = "Doe", required = true) @RequestParam(required = false) String surname,
 
 			@Deprecated // This parameter will soon be removed
-			@Parameter(description = "If the query should return a single unique result.", required = false)
-			@RequestParam(defaultValue = "true") boolean unique) {
-		log.debug("Performing passport status search using terms {}", List.of(dateOfBirth, fileNumber, givenName, surname));
+			@Parameter(description = "If the query should return a single unique result.", required = false) @RequestParam(defaultValue = "true") boolean unique) {
+		log.debug("Performing passport status search using terms {}",
+				List.of(dateOfBirth, fileNumber, givenName, surname));
 		final var initialSearchResults = service.fileNumberSearch(dateOfBirth, fileNumber, givenName, surname);
-		log.debug("{} results returned for search terms {}", initialSearchResults.size(), List.of(dateOfBirth, fileNumber, givenName, surname));
+		log.debug("{} results returned for search terms {}", initialSearchResults.size(),
+				List.of(dateOfBirth, fileNumber, givenName, surname));
 
 		log.debug("Checking results for distinct applicationRegisterSids");
-		final var applicationRegisterSids = initialSearchResults.stream().map(PassportStatus::getApplicationRegisterSid).distinct().toList();
+		final var applicationRegisterSids = initialSearchResults.stream().map(PassportStatus::getApplicationRegisterSid)
+				.distinct().toList();
 		final var nApplicationRegisterSids = applicationRegisterSids.size();
 		log.debug("Number of distinct applicationRegisterSids: {}", nApplicationRegisterSids);
 
-		final var searchEventBuilder = PassportStatusSearchEvent.builder().dateOfBirth(dateOfBirth).fileNumber(fileNumber).givenName(givenName).surname(surname);
+		final var searchEventBuilder = PassportStatusSearchEvent.builder().dateOfBirth(dateOfBirth)
+				.fileNumber(fileNumber).givenName(givenName).surname(surname);
 
 		if (nApplicationRegisterSids > 1) {
-			log.warn("Search query returned non-unique applicationRegisterSid result: {}", List.of(dateOfBirth, fileNumber, givenName, surname));
+			log.warn("Search query returned non-unique applicationRegisterSid result: {}",
+					List.of(dateOfBirth, fileNumber, givenName, surname));
 			eventPublisher.publishEvent(searchEventBuilder.result(Result.NON_UNIQUE).build());
 			throw new NonUniqueResourceException("Search query returned non-unique applicationRegisterSid result");
 		}
 
 		log.debug("Performing applicationRegisterSid search");
-		final var passportStatuses = applicationRegisterSids.stream().findFirst().map(service::applicationRegisterSidSearch).orElse(Collections.emptyList());
+		final var passportStatuses = applicationRegisterSids.stream().findFirst()
+				.map(service::applicationRegisterSidSearch).orElse(Collections.emptyList());
 		final var passportStatus = passportStatuses.stream().sorted(byVersionDesc()).findFirst();
 		log.debug("applicationRegisterSid search produced {} results", passportStatuses.size());
 
@@ -248,10 +215,13 @@ public class PassportStatusController {
 		 * TODO :: GjB :: handle INVALID status by throwing exception here
 		 */
 
-		eventPublisher.publishEvent(searchEventBuilder.result(passportStatuses.isEmpty() ? Result.MISS : Result.HIT).build());
+		eventPublisher
+				.publishEvent(searchEventBuilder.result(passportStatuses.isEmpty() ? Result.MISS : Result.HIT).build());
 
-		final var selfLink = linkTo(methodOn(getClass()).search(dateOfBirth, fileNumber, givenName, surname, unique)).withSelfRel();
-		final var collection = assembler.toCollectionModel(passportStatus.map(List::of).orElse(Collections.emptyList())).add(selfLink);
+		final var selfLink = linkTo(methodOn(getClass()).search(dateOfBirth, fileNumber, givenName, surname, unique))
+				.withSelfRel();
+		final var collection = assembler.toCollectionModel(passportStatus.map(List::of).orElse(Collections.emptyList()))
+				.add(selfLink);
 		return assembler.wrapCollection(collection, GetCertificateApplicationRepresentationModel.class);
 	}
 


### PR DESCRIPTION
Added event logging to the event handlers, in that it now logs to standard out, to satisfy the groups we're sending these logs to that we're actually logging stuff.

Some of the warnings are actually useful, ie. if we ever actually somehow see an authentication error (which should be impossible) with an IP not what we'd expect from interop that's a signal something malicious is in the VNET.

Removed the extra controller methods for querying statuses (getAll and getById), since the application doesn't use them, and even though they're behind auth, not available outside the cluster, still seems it's easier to just not have to explain them.

PS: Squash commit this if that's not the default, VS Code had some weird auto-formatting enabled I wasn't aware of for java.