### PR TITLE
Clean up authentication warning message

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
@@ -58,14 +58,10 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 
 	@Override
 	@ExceptionHandler({ AuthenticationException.class })
-	public void commence(HttpServletRequest request, HttpServletResponse response,
-			AuthenticationException authException) throws IOException {
-
-		// The only authentication we have is from Interop, so this is a canary log
-		// statement for our analytics teams, where if this happens and the IP isn't on
-		// our expected subnet we'll know something's going wrong within the VNET or
-		// wider hub/spoke.
-		log.warn("Authentication Error: Code = 401, Remote Address = " + request.getRemoteAddr());
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+		// The only authentication we have is from Interop, so this is a canary log statement for our analytics teams, where if this
+		// happens and the IP isn't on our expected subnet we'll know something's going wrong within the VNet or wider hub/spoke.
+		log.warn("Authentication Error: statusCode=401, remoteAddress={}", request.getRemoteAddr(), authException);
 
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
@@ -85,8 +81,7 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 
 	@Override
 	@ExceptionHandler({ AccessDeniedException.class })
-	public void handle(HttpServletRequest request, HttpServletResponse response,
-			AccessDeniedException accessDeniedException) throws IOException {
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
 		if (isAnonymous()) {
 			// Spring Security has this odd quirk whereby it will not throw an
 			// AuthenticationCredentialsNotFoundException if the current user is an anonymous user. 🤷
@@ -94,11 +89,9 @@ public class AuthenticationErrorHandler implements AccessDeniedHandler, Authenti
 			throw new AuthenticationCredentialsNotFoundException(accessDeniedException.getMessage());
 		}
 
-		// The only authentication we have is from Interop, so this is a canary log
-		// statement for our analytics teams, where if this happens and the IP isn't on
-		// our expected subnet we'll know something's going wrong within the VNET or
-		// wider hub/spoke.
-		log.warn("Authentication Error: Code = 403, Remote Address = " + request.getRemoteAddr());
+		// The only authentication we have is from Interop, so this is a canary log statement for our analytics teams, where if this
+		// happens and the IP isn't on our expected subnet we'll know something's going wrong within the VNet or wider hub/spoke.
+		log.warn("Authentication Error: statusCode=403, remoteAddress={}", request.getRemoteAddr(), accessDeniedException);
 
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()


### PR DESCRIPTION
Change is in preparation for upcoming Spring Boot 3.0 upgrade. The existing logging is inadequate for troubleshooting new Spring Security exceptions that are occurring after upgrade.