### PR TITLE
Upgrade to Spring Boot 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.10</version>
+		<version>3.0.5</version>
 	</parent>
 
 
@@ -67,8 +67,8 @@
 		<immutables.version>2.9.3</immutables.version>
 		<mapstruct.version>1.5.3.Final</mapstruct.version>
 		<snakeyaml.version>1.33</snakeyaml.version><!-- TODO remove when upgrading to Spring Boot 3.x -->
-		<spring-boot-configuration-processor.version>2.7.9</spring-boot-configuration-processor.version>
-		<springdoc.version>1.6.14</springdoc.version>
+		<spring-boot-configuration-processor.version>3.0.5</spring-boot-configuration-processor.version>
+		<springdoc.version>2.0.4</springdoc.version>
 	</properties>
 
 
@@ -110,7 +110,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
-			<artifactId>artemis-jms-server</artifactId>
+			<artifactId>artemis-jakarta-server</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
@@ -132,17 +132,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-hateoas</artifactId>
-			<version>${springdoc.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-security</artifactId>
-			<version>${springdoc.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-ui</artifactId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc.version}</version>
 		</dependency>
 
@@ -307,6 +297,7 @@
 				<version>${dependency-check-maven.version}</version>
 				<configuration>
 					<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+					<failOnError>false</failOnError>
 					<nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
 					<nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
 				</configuration>
@@ -323,8 +314,8 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>pl.project13.maven</groupId>
-				<artifactId>git-commit-id-plugin</artifactId>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
 				<configuration>
 					<abbrevLength>8</abbrevLength>
 					<verbose>false</verbose>

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/AsyncConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/AsyncConfig.java
@@ -1,11 +1,11 @@
 package ca.gov.dtsstn.passport.api.config;
 
-import javax.annotation.PostConstruct;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/SpringDocConfig.java
@@ -5,7 +5,7 @@ import java.time.ZoneOffset;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.context.annotation.Bean;
@@ -56,7 +56,7 @@ public class SpringDocConfig {
 
 	@Autowired ObjectMapper objectMapper;
 
-	@Bean OpenApiCustomiser openApiCustomizer(Environment environment, GitProperties gitProperties, SwaggerUiProperties swaggerUiProperties) {
+	@Bean OpenApiCustomizer openApiCustomizer(Environment environment, GitProperties gitProperties, SwaggerUiProperties swaggerUiProperties) {
 		log.info("Creating 'openApiCustomizer' bean");
 
 		return openApi -> {

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/WebMvcConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/WebMvcConfig.java
@@ -16,8 +16,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
-		log.info("Redirecting / to /swagger-ui.html");
-		registry.addRedirectViewController("/", "/swagger-ui.html");
+		log.info("Redirecting / to /swagger-ui/index.html");
+		registry.addRedirectViewController("/", "/swagger-ui/index.html");
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/ApplicationProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/ApplicationProperties.java
@@ -1,7 +1,6 @@
 package ca.gov.dtsstn.passport.api.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.annotation.Validated;
@@ -10,7 +9,6 @@ import org.springframework.validation.annotation.Validated;
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
  */
 @Validated
-@ConstructorBinding
 @ConfigurationProperties("application")
 @EnableConfigurationProperties({
 	GcNotifyProperties.class,

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/GcNotifyProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/GcNotifyProperties.java
@@ -3,12 +3,12 @@ package ca.gov.dtsstn.passport.api.config.properties;
 import java.time.Duration;
 import java.util.Optional;
 
-import javax.validation.constraints.NotBlank;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/JmsProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/JmsProperties.java
@@ -1,12 +1,12 @@
 package ca.gov.dtsstn.passport.api.config.properties;
 
-import javax.jms.Destination;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import jakarta.jms.Destination;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/SecurityProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/SecurityProperties.java
@@ -5,14 +5,14 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 import org.hibernate.validator.constraints.URL;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/SwaggerUiProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/SwaggerUiProperties.java
@@ -3,13 +3,13 @@ package ca.gov.dtsstn.passport.api.config.properties;
 import java.util.List;
 import java.util.Optional;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 import org.hibernate.validator.constraints.URL;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/PassportStatusRepository.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/PassportStatusRepository.java
@@ -19,8 +19,8 @@ public interface PassportStatusRepository extends JpaRepository<PassportStatusEn
 		SELECT ps FROM PassportStatus ps
 		 WHERE lower(email) = lower(?1)
 		   AND dateOfBirth = ?2
-		   AND lower(remove_non_alpha_numeric(remove_diacritics(givenName))) = lower(remove_non_alpha_numeric(remove_diacritics(?3)))
-		   AND lower(remove_non_alpha_numeric(remove_diacritics(surname))) = lower(remove_non_alpha_numeric(remove_diacritics(?4)))
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(givenName)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?3)) as string))
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname))   as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?4)) as string))
 		   AND version = (SELECT max(version) FROM PassportStatus other WHERE other.applicationRegisterSid = ps.applicationRegisterSid)
 	""")
 	List<PassportStatusEntity> emailSearch(String email, LocalDate dateOfBirth, String givenName, String surname);
@@ -29,8 +29,8 @@ public interface PassportStatusRepository extends JpaRepository<PassportStatusEn
 		SELECT ps FROM PassportStatus ps
 		 WHERE lower(fileNumber) = lower(?1)
 		   AND dateOfBirth = ?2
-		   AND lower(remove_non_alpha_numeric(remove_diacritics(givenName))) = lower(remove_non_alpha_numeric(remove_diacritics(?3)))
-		   AND lower(remove_non_alpha_numeric(remove_diacritics(surname))) = lower(remove_non_alpha_numeric(remove_diacritics(?4)))
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(givenName)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?3)) as string))
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname))   as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?4)) as string))
 		   AND version = (SELECT MAX(version) FROM PassportStatus other WHERE other.applicationRegisterSid = ps.applicationRegisterSid)
 	""")
 	List<PassportStatusEntity> fileNumberSearch(String fileNumber, LocalDate dateOfBirth, String givenName, String surname);

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/UuidGenerator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/UuidGenerator.java
@@ -1,15 +1,10 @@
 package ca.gov.dtsstn.passport.api.data;
 
-import java.io.Serializable;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.UUID;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.IdentifierGenerator;
-import org.hibernate.id.UUIDGenerator;
-import org.hibernate.service.ServiceRegistry;
-import org.hibernate.type.Type;
 
 /**
  * A Hibernate {@link IdentifierGenerator} that will generate a string-representation of a {@link UUID}.
@@ -30,25 +25,26 @@ public class UuidGenerator implements IdentifierGenerator {
 
 	public static final String STRATEGY = "ca.gov.dtsstn.passport.api.data.UuidGenerator";
 
-	private final UUIDGenerator delegate;
+	private final ValueGenerator valueGenerator;
 
 	public UuidGenerator() {
-		this(new UUIDGenerator());
+		this(UUID::randomUUID);
 	}
 
-	public UuidGenerator(UUIDGenerator delegate) {
-		this.delegate = delegate;
-	}
-
-	@Override
-	public void configure(Type type, Properties params, ServiceRegistry serviceRegistry) {
-		delegate.configure(type, params, serviceRegistry);
+	public UuidGenerator(ValueGenerator valueGenerator) {
+		this.valueGenerator = valueGenerator;
 	}
 
 	@Override
-	public Serializable generate(SharedSessionContractImplementor session, Object object) {
-		final Serializable id = session.getEntityPersister(null, object).getClassMetadata().getIdentifier(object, session);
-		return Optional.ofNullable(id).orElseGet(() -> delegate.generate(session, object).toString());
+	public Object generate(SharedSessionContractImplementor session, Object object) {
+		final var id = session.getEntityPersister(null, object).getIdentifier(object, session);
+		return Optional.ofNullable(id).orElseGet(() -> valueGenerator.generateUuid().toString());
+	}
+
+	public interface ValueGenerator {
+
+		UUID generateUuid();
+
 	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/AbstractEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/AbstractEntity.java
@@ -5,14 +5,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
-import javax.persistence.Transient;
-
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.data.annotation.CreatedBy;
@@ -24,6 +16,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.lang.Nullable;
 
 import ca.gov.dtsstn.passport.api.data.UuidGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
 
 /**
  *

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/EmailRequestEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/EmailRequestEntity.java
@@ -3,14 +3,14 @@ package ca.gov.dtsstn.passport.api.data.entity;
 import java.time.Instant;
 import java.time.LocalDate;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/EventLogEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/EventLogEntity.java
@@ -2,14 +2,14 @@ package ca.gov.dtsstn.passport.api.data.entity;
 
 import java.time.Instant;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/HttpRequestEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/HttpRequestEntity.java
@@ -2,12 +2,12 @@ package ca.gov.dtsstn.passport.api.data.entity;
 
 import java.time.Instant;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/PassportStatusEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/PassportStatusEntity.java
@@ -4,13 +4,13 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/StatusCodeEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/StatusCodeEntity.java
@@ -2,12 +2,12 @@ package ca.gov.dtsstn.passport.api.data.entity;
 
 import java.time.Instant;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 
 /**
  * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/StatusCodeMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/StatusCodeMapper.java
@@ -2,8 +2,6 @@ package ca.gov.dtsstn.passport.api.service.domain.mapper;
 
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
-
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +11,7 @@ import org.springframework.util.Assert;
 import ca.gov.dtsstn.passport.api.data.entity.StatusCodeEntity;
 import ca.gov.dtsstn.passport.api.service.StatusCodeService;
 import ca.gov.dtsstn.passport.api.service.domain.StatusCode;
+import jakarta.annotation.PostConstruct;
 
 /**
  * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/utils/StringUtils.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/utils/StringUtils.java
@@ -5,10 +5,28 @@ package ca.gov.dtsstn.passport.api.utils;
  */
 public class StringUtils {
 
-	protected StringUtils() {
-	}
+	protected StringUtils() {}
 
 	/**
+	 * <p>Removes diacritics (~= accents) from a string. The case will not be altered.</p>
+	 * <p>For instance, '&agrave;' will be replaced by 'a'.</p>
+	 * <p>Note that ligatures will be left as is.</p>
+	 *
+	 * <pre>
+	 * StringUtils.stripAccents(null) = null
+	 * StringUtils.stripAccents("") = ""
+	 * StringUtils.stripAccents("control") = "control"
+	 * StringUtils.stripAccents("&eacute;clair") = "eclair"
+	 * </pre>
+	 *
+	 * @param input String to be stripped
+	 * @return input text with diacritics removed
+	 */
+	public static String stripAccents(String input) {
+		return org.apache.commons.lang3.StringUtils.stripAccents(input);
+	}
+
+	 /**
 	 * <p>Removes all non alpha-numeric characters from a string. The case will not be altered.</p>
 	 * <p>For instance, '(A)B,.C|d_e1&eacute;@!.>' will be replaced by 'ABCde1'.</p>
 	 * <p>Note that accent character will be removed.</p>

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/ApiErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/ApiErrorHandler.java
@@ -3,10 +3,6 @@ package ca.gov.dtsstn.passport.api.web;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Path;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.TypeMismatchException;
@@ -14,6 +10,7 @@ import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -39,6 +36,9 @@ import ca.gov.dtsstn.passport.api.web.model.ImmutableIssueModel;
 import ca.gov.dtsstn.passport.api.web.model.ImmutableOperationOutcomeModel;
 import ca.gov.dtsstn.passport.api.web.model.ImmutableOperationOutcomeStatusModel;
 import ca.gov.dtsstn.passport.api.web.model.IssueModel;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
 
 /**
  * API global error handler.
@@ -52,7 +52,7 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
 	private static final Logger log = LoggerFactory.getLogger(ApiErrorHandler.class);
 
 	@Override
-	protected ResponseEntity<Object> handleBindException(BindException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+	protected ResponseEntity<Object> handleBindException(BindException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
 				.addAllIssues(ex.getFieldErrors().stream().map(this::toIssue).toList())
@@ -71,7 +71,7 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
 	 * (ie: when the incoming JSON is malformed)
 	 */
 	@Override
-	protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+	protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
 				.addIssues(ImmutableIssueModel.builder()
@@ -93,7 +93,7 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
 	 * (ie: {@code POST} to {@code /api/v1/passport-statuses} with an invalid date of birth in the request body)
 	 */
 	@Override
-	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
 				.addAllIssues(ex.getFieldErrors().stream().map(this::toIssue).toList())
@@ -108,7 +108,7 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
 	}
 
 	@Override
-	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
 				.addIssues(ImmutableIssueModel.builder()
@@ -126,7 +126,7 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
 	}
 
 	@Override
-	protected ResponseEntity<Object> handleServletRequestBindingException(ServletRequestBindingException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+	protected ResponseEntity<Object> handleServletRequestBindingException(ServletRequestBindingException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		final var body = ImmutableErrorResponseModel.builder()
 			.operationOutcome(ImmutableOperationOutcomeModel.builder()
 				.addIssues(ImmutableIssueModel.builder()
@@ -144,7 +144,7 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
 	}
 
 	@Override
-	protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+	protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 		final var fieldName = ClassUtils.isAssignableValue(MethodArgumentTypeMismatchException.class, ex)
 			? ((MethodArgumentTypeMismatchException) ex).getName() : ex.getPropertyName();
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/AuthenticationErrorHandler.java
@@ -4,9 +4,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
@@ -32,6 +29,8 @@ import ca.gov.dtsstn.passport.api.web.model.ImmutableErrorResponseModel;
 import ca.gov.dtsstn.passport.api.web.model.ImmutableIssueModel;
 import ca.gov.dtsstn.passport.api.web.model.ImmutableOperationOutcomeModel;
 import ca.gov.dtsstn.passport.api.web.model.ImmutableOperationOutcomeStatusModel;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * This class functions as both a {@code RestControllerAdvice}, as well as a

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/PassportStatusController.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/PassportStatusController.java
@@ -8,11 +8,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import javax.validation.ConstraintViolationException;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.PastOrPresent;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +46,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/filter/RequestLoggingFilter.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/filter/RequestLoggingFilter.java
@@ -4,13 +4,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.AbstractRequestLoggingFilter;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/BirthDateModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/BirthDateModel.java
@@ -3,10 +3,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 import java.io.Serializable;
 import java.time.LocalDate;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.PastOrPresent;
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -15,6 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationApplicantModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationApplicantModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -14,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentificationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationIdentificationModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -13,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationModel.java
@@ -4,9 +4,6 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -19,6 +16,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import ca.gov.dtsstn.passport.api.web.annotation.Authorities;
 import ca.gov.dtsstn.passport.api.web.validation.CertificateApplicationIdentification;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationStatusModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CertificateApplicationStatusModel.java
@@ -2,11 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -19,6 +14,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import ca.gov.dtsstn.passport.api.web.annotation.Authorities;
 import ca.gov.dtsstn.passport.api.web.validation.PassportStatusCode;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/ClientModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/ClientModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -14,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CreateCertificateApplicationRequestModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CreateCertificateApplicationRequestModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -14,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/CreateElectronicServiceRequestModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/CreateElectronicServiceRequestModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
@@ -12,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/GetCertificateApplicationRepresentationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/GetCertificateApplicationRepresentationModel.java
@@ -2,8 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.util.Objects;
 
-import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.hateoas.Link;
@@ -14,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonContactInformationModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonContactInformationModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -13,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonNameModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonNameModel.java
@@ -4,10 +4,6 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
@@ -17,6 +13,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonPreferredLanguageModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonPreferredLanguageModel.java
@@ -2,8 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.constraints.NotNull;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -13,6 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import ca.gov.dtsstn.passport.api.web.validation.ValueOfEnum;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/ResourceMetaModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/ResourceMetaModel.java
@@ -2,9 +2,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.NotBlank;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -13,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/StatusDateModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/StatusDateModel.java
@@ -3,10 +3,6 @@ package ca.gov.dtsstn.passport.api.web.model;
 import java.io.Serializable;
 import java.time.LocalDate;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.PastOrPresent;
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -15,6 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/BooleanString.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/BooleanString.java
@@ -5,8 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/BooleanStringValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/BooleanStringValidator.java
@@ -1,9 +1,9 @@
 package ca.gov.dtsstn.passport.api.web.validation;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
 import org.springframework.stereotype.Component;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * Checks that a string represents a boolean value.

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentification.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentification.java
@@ -5,8 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentificationValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CertificateApplicationIdentificationValidator.java
@@ -4,14 +4,13 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import ca.gov.dtsstn.passport.api.web.model.CertificateApplicationIdentificationModel;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * Checks that a collection of {@link CertificateApplicationIdentificationModel} has both

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CustomValidatorFactoryBean.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/CustomValidatorFactoryBean.java
@@ -1,9 +1,5 @@
 package ca.gov.dtsstn.passport.api.web.validation;
 
-import javax.validation.Configuration;
-import javax.validation.ConstraintViolation;
-import javax.validation.constraints.PastOrPresent;
-
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +11,10 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import jakarta.validation.Configuration;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.constraints.PastOrPresent;
 
 /**
  * A custom {@link LocalValidatorFactoryBean} that works with {@link JacksonPropertyNodeNameProvider}.

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/Date.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/Date.java
@@ -5,8 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/DateValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/DateValidator.java
@@ -3,10 +3,10 @@ package ca.gov.dtsstn.passport.api.web.validation;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
 import org.springframework.stereotype.Component;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * Checks that a string is a valid ISO 8601 compliant date.

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/PassportStatusCode.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/PassportStatusCode.java
@@ -5,8 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/PassportStatusCodeValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/PassportStatusCodeValidator.java
@@ -1,12 +1,11 @@
 package ca.gov.dtsstn.passport.api.web.validation;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
 import org.springframework.stereotype.Component;
 
 import ca.gov.dtsstn.passport.api.service.StatusCodeService;
 import ca.gov.dtsstn.passport.api.service.domain.StatusCode;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * Checks that a string is a valid passport status code.

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/PastOrPresentValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/PastOrPresentValidator.java
@@ -3,13 +3,13 @@ package ca.gov.dtsstn.passport.api.web.validation;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraints.PastOrPresent;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.constraints.PastOrPresent;
 
 /**
  * Checks that a string represents a date in the past or present.

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ValueOfEnum.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ValueOfEnum.java
@@ -5,8 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = ValueOfEnumValidator.class)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ValueOfEnumValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ValueOfEnumValidator.java
@@ -3,8 +3,8 @@ package ca.gov.dtsstn.passport.api.web.validation;
 import java.util.List;
 import java.util.stream.Stream;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 public class ValueOfEnumValidator implements ConstraintValidator<ValueOfEnum, String> {
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,13 +32,18 @@ logging:
 #######################################################################################################################
 
 management:
+  authorized-role: Application.Manage
   endpoint:
+    env:
+      show-values: when-authorized
     health:
       probes:
         enabled: true
       show-components: always
       show-details: when-authorized
   endpoints:
+    jackson:
+      isolated-object-mapper: false
     web:
       exposure:
         include:
@@ -46,14 +51,14 @@ management:
           - changelog
           - env
           - health
-          - httptrace
+          - httpexchanges
           - info
           - initdata
           - metrics
           - prometheus
           - refresh
-  trace:
-    http:
+  httpexchanges:
+    recording:
       include:
         - principal
         - remote-address
@@ -180,16 +185,16 @@ application:
       changelog-path: changelog.json  # classpath location of the changelog.json file generated during build
   gcnotify:
     english-api-key: # must be set externally (ex: 00000000-0000-0000-0000-000000000000)
-    french-api-key: # must be set externally (ex: 00000000-0000-0000-0000-000000000000)
+    french-api-key:  # must be set externally (ex: 00000000-0000-0000-0000-000000000000)
     base-url: https://api.notification.canada.ca/v2/notifications/email
     file-number-notification:
       english-template-id: # must be set externally (ex: 00000000-0000-0000-0000-000000000000)
-      french-template-id: # must be set externally (ex: 00000000-0000-0000-0000-000000000000)
+      french-template-id:  # must be set externally (ex: 00000000-0000-0000-0000-000000000000)
   http-request-repository:
-    page-size: 100                    # number of http request/response trace requests to return from /actuator/httptrace
-    includeUrls:                      # list of URLs to include, in ant path style
+    page-size: 100 # number of http request/response trace requests to return from /actuator/httptrace
+    includeUrls:   # list of URLs to include, in ant path style
       - /**
-    excludeUrls:                      # list of URLs to exclude, in ant path style
+    excludeUrls:   # list of URLs to exclude, in ant path style
       - /actuator/health/liveness
       - /actuator/health/readiness
   jms:
@@ -198,7 +203,7 @@ application:
   security:
     content-security-policy:
       default-src: "'self'"
-      connect-src: "'self' login.microsoftonline.com passport-status-api.dev.dev-rhp.dts-stn.com passport-status-api.staging.dev-rhp.dts-stn.com"
+      connect-src: "'self' login.microsoftonline.com"
       img-src: "'self' data:"
       script-src: "'self' 'sha256-4IiDsMH+GkJlxivIDNfi6qk0O5HPtzyvNwVT3Wt8TIw='"
     cors:
@@ -219,13 +224,13 @@ application:
       tenant-id: # must be set externally (sample: 00000000-0000-0000-0000-000000000000)
       token-url: https://login.microsoftonline.com/${application.security.oauth.tenant-id}/oauth2/v2.0/token
   request-logging-filter:
-    enabled: false                    # whether to enable the request logging filter
-    includeUrls:                      # list of URLs to include, in ant path style
+    enabled: false # whether to enable the request logging filter
+    includeUrls:   # list of URLs to include, in ant path style
       - /**
-    excludeUrls:                      # list of URLs to exclude, in ant path style
+    excludeUrls:   # list of URLs to exclude, in ant path style
       - /actuator/health/liveness
       - /actuator/health/readiness
-    include-headers: true             # whether the request headers should be included in the log message
-    include-payload: true             # whether the request payload (body) should be included in the log message
-    include-query-string: true        # whether the query string should be included in the log message
-    max-payload-length: 10240         # the maximum length (in bytes) of the payload body to be included in the log messagehttp
+    include-headers: true      # whether the request headers should be included in the log message
+    include-payload: true      # whether the request payload (body) should be included in the log message
+    include-query-string: true # whether the query string should be included in the log message
+    max-payload-length: 10240  # the maximum length (in bytes) of the payload body to be included in the log message

--- a/src/main/resources/db-migrations/common/v2-[common]-schema-update.sql
+++ b/src/main/resources/db-migrations/common/v2-[common]-schema-update.sql
@@ -1,0 +1,1 @@
+-- there is no 'common' schema update for v2; this file exists only as a placeholder to ensure concurrent numbering in migration scripts

--- a/src/main/resources/db-migrations/h2/v0.1-[vendor]-schema-init.sql
+++ b/src/main/resources/db-migrations/h2/v0.1-[vendor]-schema-init.sql
@@ -1,2 +1,2 @@
-CREATE ALIAS remove_diacritics FOR 'org.apache.commons.lang3.StringUtils.stripAccents';
+CREATE ALIAS remove_diacritics FOR 'ca.gov.dtsstn.passport.api.utils.StringUtils.stripAccents';
 CREATE ALIAS remove_non_alpha_numeric FOR 'ca.gov.dtsstn.passport.api.utils.StringUtils.stripNonAlphaNumeric';

--- a/src/main/resources/db-migrations/postgresql/v2.1-[vendor]-schema-update.sql
+++ b/src/main/resources/db-migrations/postgresql/v2.1-[vendor]-schema-update.sql
@@ -1,0 +1,7 @@
+DROP INDEX ix_given_name;
+CREATE INDEX ix_given_name ON passport_status(lower(cast(remove_non_alpha_numeric(remove_diacritics(given_name)) as text)));
+REINDEX INDEX ix_given_name;
+
+DROP INDEX ix_surname;
+CREATE INDEX ix_surname ON passport_status(lower(cast(remove_non_alpha_numeric(remove_diacritics(surname)) as text)));
+REINDEX INDEX ix_surname;

--- a/src/test/java/ca/gov/dtsstn/passport/api/WebMvcIT.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/WebMvcIT.java
@@ -29,7 +29,7 @@ class WebMvcIT {
 	@Test void testSwaggerRedirect() throws Exception {
 		mvc.perform(get("/"))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("/swagger-ui.html"));
+			.andExpect(redirectedUrl("/swagger-ui/index.html"));
 	}
 
 }

--- a/src/test/java/ca/gov/dtsstn/passport/api/data/UuidGeneratorTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/data/UuidGeneratorTests.java
@@ -3,13 +3,11 @@ package ca.gov.dtsstn.passport.api.data;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.id.UUIDGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith({ MockitoExtension.class })
 class UuidGeneratorTests {
 
-	@Mock UUIDGenerator uuidGeneratorDelegate;
+	@Mock UuidGenerator.ValueGenerator valueGenerator;
 
 	UuidGenerator uuidGenerator;
 
@@ -32,27 +30,21 @@ class UuidGeneratorTests {
 
 	@BeforeEach
 	void setUp() {
-		this.uuidGenerator = new UuidGenerator(uuidGeneratorDelegate);
-	}
-
-	@Test
-	void testConfigureCallsDelegate() {
-		uuidGenerator.configure(null, null, null);
-		verify(uuidGeneratorDelegate).configure(null, null, null);
+		this.uuidGenerator = new UuidGenerator(valueGenerator);
 	}
 
 	@Test
 	void testGenerate_withId() {
 		final SharedSessionContractImplementor sharedSessionContractImplementor = mock(SharedSessionContractImplementor.class, Mockito.RETURNS_DEEP_STUBS);
-		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getClassMetadata().getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(id.toString());
+		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(id.toString());
 		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, new Object())).asString().isEqualTo(id.toString());
 	}
 
 	@Test
 	void testGenerate_withNullId() {
 		final SharedSessionContractImplementor sharedSessionContractImplementor = mock(SharedSessionContractImplementor.class, Mockito.RETURNS_DEEP_STUBS);
-		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getClassMetadata().getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(null);
-		when(uuidGeneratorDelegate.generate(any(), any())).thenReturn(id);
+		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(null);
+		when(valueGenerator.generateUuid()).thenReturn(id);
 		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, new Object())).asString().isEqualTo(id.toString());
 	}
 

--- a/src/test/java/ca/gov/dtsstn/passport/api/web/validation/ValueOfEnumTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/web/validation/ValueOfEnumTests.java
@@ -4,14 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Predicate;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Valid;
-import javax.validation.Validation;
-import javax.validation.Validator;
-
 import org.junit.jupiter.api.BeforeAll;
 
 import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 /**
  * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)


### PR DESCRIPTION
## Prologue

Apologies in advance for the size of this PR. I tried to break it into multiple PRs, but it just wasn't possible given the nature of the change.

## Changes

- Bump Spring Boot to v3.0.5
- Bump SpringDoc to v2.0.4
- Reconfigure `dependency-check-maven` to not fail a build when OWASP sites are down
- Change `pl.project13.maven#git-commit-id-plugin` to `io.github.git-commit-id#git-commit-id-maven-plugin`
- Modify database indexes to work with new version of H2 (add `cast(..)` to function calls)
- Change `javax.*` packages to `jakarta.*`
- Change `org.springframework.boot.actuate.trace.*` packages to `org.springframework.boot.actuate.web.exchanges.*`
- Remove unnecessary `@ConstructorBinding` on property classes
- Fix broken Spring Security
- Fix broken `UuidGenerator`
- Fix broken tests
- A few other small fixes

## References

- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide
- https://docs.spring.io/spring-boot/docs/3.0.5/reference/htmlsingle/
- https://docs.spring.io/spring-security/reference/6.0.2/index.html
- https://springdoc.org/v2/
