### PR TITLE
Add `source_code` DB table and necessary migrations

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/data/SourceCodeRepository.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/SourceCodeRepository.java
@@ -1,0 +1,19 @@
+package ca.gov.dtsstn.passport.api.data;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ca.gov.dtsstn.passport.api.data.entity.SourceCodeEntity;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+public interface SourceCodeRepository extends JpaRepository<SourceCodeEntity, String> {
+
+	Optional<SourceCodeEntity> findByCdoCode(String cdoCode);
+
+	List<SourceCodeEntity> findAllByIsActive(boolean isActive);
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/PassportStatusEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/PassportStatusEntity.java
@@ -40,7 +40,10 @@ public class PassportStatusEntity extends AbstractEntity {
 	@Column(length = 64, nullable = false)
 	private String surname;
 
-	@ManyToOne()
+	@ManyToOne
+	private SourceCodeEntity sourceCode;
+
+	@ManyToOne
 	private StatusCodeEntity statusCode;
 
 	@Column(nullable = false)
@@ -68,6 +71,7 @@ public class PassportStatusEntity extends AbstractEntity {
 			@Nullable String givenName,
 			@Nullable String manifestNumber,
 			@Nullable String surname,
+			@Nullable SourceCodeEntity sourceCode,
 			@Nullable StatusCodeEntity statusCode,
 			@Nullable LocalDate statusDate,
 			@Nullable Long version) {
@@ -79,6 +83,7 @@ public class PassportStatusEntity extends AbstractEntity {
 		this.givenName = givenName;
 		this.manifestNumber = manifestNumber;
 		this.surname = surname;
+		this.sourceCode = sourceCode;
 		this.statusCode = statusCode;
 		this.statusDate = statusDate;
 		this.version = version;
@@ -140,6 +145,14 @@ public class PassportStatusEntity extends AbstractEntity {
 		this.surname = surname;
 	}
 
+	public SourceCodeEntity getSourceCode() {
+		return this.sourceCode;
+	}
+
+	public void setSourceCode(SourceCodeEntity sourceCode) {
+		this.sourceCode = sourceCode;
+	}
+
 	public StatusCodeEntity getStatusCode() {
 		return this.statusCode;
 	}
@@ -187,6 +200,9 @@ public class PassportStatusEntity extends AbstractEntity {
 			.append("givenName", givenName)
 			.append("manifestNumber", manifestNumber)
 			.append("surname", surname)
+			.append("sourceCode", Optional.ofNullable(sourceCode)
+				.map(SourceCodeEntity::getCode)
+				.orElse(null))
 			.append("statusCode", Optional.ofNullable(statusCode)
 				.map(StatusCodeEntity::getCode)
 				.orElse(null))

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/SourceCodeEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/SourceCodeEntity.java
@@ -1,0 +1,113 @@
+package ca.gov.dtsstn.passport.api.data.entity;
+
+import java.time.Instant;
+
+import org.immutables.builder.Builder;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.lang.Nullable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Entity(name = "SourceCode")
+@SuppressWarnings({ "serial" })
+public class SourceCodeEntity extends AbstractEntity {
+
+	@Column(length = 16, nullable = false)
+	private String code;
+
+	@Column(length = 8, nullable = false)
+	private String cdoCode;
+
+	@Column(length = 256)
+	private String description;
+
+	@Column(nullable = false)
+	private Boolean isActive;
+
+	public SourceCodeEntity() {
+		super();
+	}
+
+	@Builder.Constructor
+	protected SourceCodeEntity( // NOSONAR (too many parameters)
+			@Nullable String id,
+			@Nullable String createdBy,
+			@Nullable Instant createdDate,
+			@Nullable String lastModifiedBy,
+			@Nullable Instant lastModifiedDate,
+			@Nullable Boolean isNew,
+			@Nullable String code,
+			@Nullable String cdoCode,
+			@Nullable String description,
+			@Nullable Boolean isActive) {
+		super(id, createdBy, createdDate, lastModifiedBy, lastModifiedDate, isNew);
+		this.code = code;
+		this.cdoCode = cdoCode;
+		this.description = description;
+		this.isActive = isActive;
+	}
+
+	public String getCode() {
+		return this.code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public String getCdoCode() {
+		return this.cdoCode;
+	}
+
+	public void setCdoCode(String cdoCode) {
+		this.cdoCode = cdoCode;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Boolean isIsActive() {
+		return this.isActive;
+	}
+
+	public Boolean getIsActive() {
+		return this.isActive;
+	}
+
+	public void setIsActive(Boolean isActive) {
+		this.isActive = isActive;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		// keeps SonarLint happy
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		// keeps SonarLint happy
+		return super.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this)
+			.append("super", super.toString())
+			.append("code", code)
+			.append("cdoCode", cdoCode)
+			.append("description", description)
+			.append("isActive", isActive)
+			.toString();
+	}
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/PassportStatusMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/PassportStatusMapper.java
@@ -8,6 +8,7 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.springframework.lang.Nullable;
 
 import ca.gov.dtsstn.passport.api.data.entity.PassportStatusEntity;
+import ca.gov.dtsstn.passport.api.data.entity.SourceCodeEntity;
 import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 
 /**
@@ -18,8 +19,27 @@ import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 @Mapper(componentModel = "spring", uses = { StatusCodeMapper.class })
 public interface PassportStatusMapper {
 
+	/**
+	 * ID of the IRIS source system; see: src/main/resources/db-migrations/common/v3-[common]-add-source-code-table.sql
+	 *
+	 * TODO :: GjB :: remove in future commit
+	 */
+	static final String IRIS_SOURCE_ID = "327c25eb-e3f4-492e-bd47-4feb20189e78";
+
+	/**
+	 * Temporary method that will generate a SourceCodeEntity that maps to IRIS.
+	 *
+	 * TODO :: GjB :: remove this and create an actual mapper in a future commit
+	 */
+	default SourceCodeEntity irisSourceCode() {
+		final var sourceCode = new SourceCodeEntity();
+		sourceCode.setId(IRIS_SOURCE_ID);
+		return sourceCode;
+	}
+
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
+	@Mapping(target = "sourceCode", expression = "java(irisSourceCode())") // TODO :: GjB :: remove in future commit
 	@Mapping(target = "statusCode", source = "statusCodeId")
 	PassportStatusEntity toEntity(@Nullable PassportStatus passportStatus);
 
@@ -33,6 +53,7 @@ public interface PassportStatusMapper {
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
 	@Mapping(target = "isNew", ignore = true)
+	@Mapping(target = "sourceCode", expression = "java(irisSourceCode())") // TODO :: GjB :: remove in future commit
 	@Mapping(target = "statusCode", source = "statusCodeId")
 	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 	PassportStatusEntity update(@Nullable PassportStatus passportStatus, @MappingTarget PassportStatusEntity target);

--- a/src/main/resources/db-migrations/common/v3-[common]-add-source-code-table.sql
+++ b/src/main/resources/db-migrations/common/v3-[common]-add-source-code-table.sql
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Migration file for Passport Application Status Checker release 2.0.
+ *
+ * PASC v2.0 will include support for multiple data source systems. Prior to
+ * v2.0, passport data was sourced from the IRIS passport system. From v2.0
+ * onwards, data can be sourced from the IRIS, GCMS, or Tempo passport systems.
+ *
+ * To add support for the new data source systems, this migration file will
+ * perform the following migrations:
+ *
+ *   - create a new table called `source_code` which represents the source system's CDO code
+ *   - populate the new table with the initial data representing IRIS, GCMS, and Tempo
+ *   - modify the `passport_status` table to add a column called `source_code_id` that joins to the new `source_code` table
+ *
+ * Initially, the `source_code_id` column will use a default value that corresponds to the
+ * IRIS passport system, which will force all existing rows to be updated to use the IRIS source code.
+ * This default value will then be removed to ensure that future rows must have the source code set on insert.
+ */
+
+-------------------------------------------------------------------------------
+-- create a new table called `source_code` which represents the source system's CDO code
+-------------------------------------------------------------------------------
+
+CREATE TABLE source_code
+(
+	id VARCHAR(64) NOT NULL,
+
+	cdo_code VARCHAR(8) NOT NULL,
+	code VARCHAR(64) NOT NULL,
+	description VARCHAR(256),
+	is_active BOOLEAN NOT NULL,
+
+	-- audit fields
+	created_by VARCHAR(64) NOT NULL,
+	created_date TIMESTAMP NOT NULL,
+	last_modified_by VARCHAR(64),
+	last_modified_date TIMESTAMP,
+
+	CONSTRAINT pk_source_code PRIMARY KEY (id)
+);
+
+CREATE INDEX ix_source_code_cdo_code ON source_code(cdo_code);
+CREATE INDEX ix_source_code_code ON source_code(code);
+
+-------------------------------------------------------------------------------
+-- populate the new table with the initial data representing IRIS, GCMS, and Tempo
+-------------------------------------------------------------------------------
+
+INSERT INTO source_code
+	(id, code, cdo_code, description, is_active, created_by, created_date, last_modified_by, last_modified_date)
+VALUES
+	('c0d1b52d-3107-41d4-bd4b-00d4e99829db', 'TEMPO', '32', 'Tempo Application', true, 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
+	('61918f07-9dc7-4b84-a2e5-031dcaa0f547', 'GCMS',  '33', 'GCMS Application',  true, 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP),
+	('327c25eb-e3f4-492e-bd47-4feb20189e78', 'IRIS',  '36', 'IRIS Application',  true, 'flyway-community-edition', CURRENT_TIMESTAMP, 'flyway-community-edition', CURRENT_TIMESTAMP);
+
+-------------------------------------------------------------------------------
+-- modify the `passport_status` table to add a column called `source_code_id` that joins to the new `source_code` table
+-------------------------------------------------------------------------------
+
+ALTER TABLE passport_status ADD COLUMN source_code_id VARCHAR(64) NOT NULL DEFAULT '327c25eb-e3f4-492e-bd47-4feb20189e78';
+ALTER TABLE passport_status ADD CONSTRAINT fk_passport_status_source_code FOREIGN KEY (source_code_id) REFERENCES source_code(id);
+ALTER TABLE passport_status ALTER COLUMN source_code_id DROP DEFAULT;


### PR DESCRIPTION
## List of changes

- Add new `source_code` lookup table that represents downstream data source (IRIS, GCMS, Tempo)
- Populate `source_code` lookup table with existing known sources (IRIS, GCMS, Tempo)
- Alter `passport_status` table and a new `source_code_id` column which joins to new `source_code` table; set the default value to IRIS so existing rows will be properly populated
- Alter `passport_status` table to remove default `source_code_id`
- Update JPA entities and add `SourceCodeRepository`
- Hack `PassportStatusMapper` to ensure all new requests have the source ID set to IRIS

## Future changes

As of right now, the public-facing interface for this API has not changed. The source system will be automatically set to IRIS for all new requests. In a future PR, the source system field will be exposed and all consumers of this API will be required to send the correct code.

## Important notes

- The flyway migration that has been included in this PR has been tested on both H2 and Postgres. Existing rows in the `passport_status` table had their `source_code_id` value correctly set to IRIS after the migration
- All unit tests are still passing after this change
