### PR TITLE
Fix logical bug in StatusCodeService

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/service/StatusCodeService.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/StatusCodeService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.mapstruct.factory.Mappers;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -23,12 +24,14 @@ import ca.gov.dtsstn.passport.api.service.domain.mapper.StatusCodeMapper;
 @CacheConfig(cacheNames = { "status-codes" })
 public class StatusCodeService {
 
-	private final StatusCodeMapper mapper = Mappers.getMapper(StatusCodeMapper.class);
+	private final StatusCodeMapper mapper;
 
 	private final StatusCodeRepository repository;
 
-	public StatusCodeService(StatusCodeRepository repository) {
+	public StatusCodeService(@Lazy StatusCodeMapper mapper, StatusCodeRepository repository) {
+		Assert.notNull(mapper, "mapper is required; it must not be null");
 		Assert.notNull(repository, "repository is required; it must not be null");
+		this.mapper = mapper;
 		this.repository = repository;
 	}
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/StatusCodeMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/StatusCodeMapper.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -19,6 +20,7 @@ import jakarta.annotation.PostConstruct;
 @Mapper(componentModel = "spring")
 public abstract class StatusCodeMapper {
 
+	@Autowired
 	protected StatusCodeService statusCodeService;
 
 	@PostConstruct
@@ -40,11 +42,5 @@ public abstract class StatusCodeMapper {
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
 	public abstract StatusCodeEntity toEntity(@Nullable StatusCode passportStatus);
-
-	@Autowired
-	public void setStatusCodeService(StatusCodeService statusCodeService) {
-		Assert.notNull(statusCodeService, "statusCodeService is required; it must not be null");
-		this.statusCodeService = statusCodeService;
-	}
 
 }


### PR DESCRIPTION
Fixing issue with how the StatusCodeMapper was being wired into StatusCodeService. Since these two classes are dependent on each other, the mapper must be injected lazily into the service.