### PR TITLE
Implement source code field in service layer

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/config/CacheConfig.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/CacheConfig.java
@@ -26,6 +26,12 @@ public class CacheConfig {
 		return new CaffeineCacheFactory("esrf-emails");
 	}
 
+	@ConfigurationProperties("application.caching.caches.source-codes")
+	@Bean CaffeineCacheFactory sourceCodesCache() {
+		log.info("Creating 'sourceCodesCache' bean");
+		return new CaffeineCacheFactory("source-codes");
+	}
+
 	@ConfigurationProperties("application.caching.caches.status-codes")
 	@Bean CaffeineCacheFactory statusCodesCache() {
 		log.info("Creating 'statusCodesCache' bean");

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/PassportStatusService.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/PassportStatusService.java
@@ -16,6 +16,7 @@ import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusCreatedEvent;
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusDeletedEvent;
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusReadEvent;
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusUpdatedEvent;
+import ca.gov.dtsstn.passport.api.service.domain.ImmutablePassportStatus;
 import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 import ca.gov.dtsstn.passport.api.service.domain.mapper.PassportStatusMapper;
 
@@ -26,6 +27,8 @@ import ca.gov.dtsstn.passport.api.service.domain.mapper.PassportStatusMapper;
  */
 @Service
 public class PassportStatusService {
+
+	private static final String IRIS_ID = "327c25eb-e3f4-492e-bd47-4feb20189e78";
 
 	private final ApplicationEventPublisher eventPublisher;
 
@@ -52,7 +55,10 @@ public class PassportStatusService {
 			return existingPassportStatus.get();
 		}
 
-		final var createdPassportStatus = mapper.fromEntity(repository.save(mapper.toEntity(passportStatus))); // NOSONAR (nullable param)
+		// TODO :: GjB :: remove this when exposing source field in API models
+		final var tmpPassportStatus = ImmutablePassportStatus.copyOf(passportStatus).withSourceCodeId(IRIS_ID);
+
+		final var createdPassportStatus = mapper.fromEntity(repository.save(mapper.toEntity(tmpPassportStatus))); // NOSONAR (nullable param)
 		eventPublisher.publishEvent(ImmutablePassportStatusCreatedEvent.of(createdPassportStatus));
 		return createdPassportStatus;
 	}
@@ -68,7 +74,11 @@ public class PassportStatusService {
 		Assert.notNull(passportStatus, "passportStatus is required; it must not be null");
 		Assert.notNull(passportStatus.getId(), "passportStatus.id must not be null when updating existing instance");
 		final var originalPassportStatus = repository.findById(passportStatus.getId()).orElseThrow(); // NOSONAR (nullable param)
-		final var updatedPassportStatus = mapper.fromEntity(repository.save(mapper.update(passportStatus, originalPassportStatus)));
+
+		// TODO :: GjB :: remove this when exposing source field in API models
+		final var tmpPassportStatus = ImmutablePassportStatus.copyOf(passportStatus).withSourceCodeId(IRIS_ID);
+
+		final var updatedPassportStatus = mapper.fromEntity(repository.save(mapper.update(tmpPassportStatus, originalPassportStatus)));
 		eventPublisher.publishEvent(ImmutablePassportStatusUpdatedEvent.of(mapper.fromEntity(originalPassportStatus), updatedPassportStatus));
 		return updatedPassportStatus;
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/SourceCodeService.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/SourceCodeService.java
@@ -9,25 +9,24 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
-import ca.gov.dtsstn.passport.api.data.StatusCodeRepository;
-import ca.gov.dtsstn.passport.api.service.domain.StatusCode;
-import ca.gov.dtsstn.passport.api.service.domain.mapper.StatusCodeMapper;
+import ca.gov.dtsstn.passport.api.data.SourceCodeRepository;
+import ca.gov.dtsstn.passport.api.service.domain.SourceCode;
+import ca.gov.dtsstn.passport.api.service.domain.mapper.SourceCodeMapper;
 
 /**
- * Service class to handle {@link StatusCode} interactions.
+ * Service class to handle {@link SourceCode} interactions.
  *
- * @author Sébastien Comeau (sebastien.comeau@hrsdc-rhdcc.gc.ca)
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
  */
 @Service
-@CacheConfig(cacheNames = { "status-codes" })
-public class StatusCodeService {
+@CacheConfig(cacheNames = { "source-codes" })
+public class SourceCodeService {
 
-	private final StatusCodeMapper mapper;
+	private final SourceCodeMapper mapper;
 
-	private final StatusCodeRepository repository;
+	private final SourceCodeRepository repository;
 
-	public StatusCodeService(@Lazy StatusCodeMapper mapper, StatusCodeRepository repository) {
+	public SourceCodeService(@Lazy SourceCodeMapper mapper, SourceCodeRepository repository) {
 		Assert.notNull(mapper, "mapper is required; it must not be null");
 		Assert.notNull(repository, "repository is required; it must not be null");
 		this.mapper = mapper;
@@ -35,24 +34,24 @@ public class StatusCodeService {
 	}
 
 	@Cacheable(key = "{ 'id', #id }")
-	public Optional<StatusCode> read(String id) {
+	public Optional<SourceCode> read(String id) {
 		Assert.hasText(id, "id is required; it must not be null or blank");
 		return repository.findById(id).map(mapper::fromEntity);
 	}
 
 	@Cacheable(key = "{ 'cdoCode', #cdoCode }")
-	public Optional<StatusCode> readByCdoCode(String cdoCode) {
+	public Optional<SourceCode> readByCdoCode(String cdoCode) {
 		Assert.notNull(cdoCode, "cdoCode is required; it must not be null");
 		return repository.findByCdoCode(cdoCode).map(mapper::fromEntity);
 	}
 
 	@Cacheable(key = "{ 'all' }")
-	public List<StatusCode> readAll() {
+	public List<SourceCode> readAll() {
 		return repository.findAll().stream().map(mapper::fromEntity).toList();
 	}
 
 	@Cacheable(key = "{ 'isActive', #isActive }")
-	public List<StatusCode> readAllByIsActive(boolean isActive) {
+	public List<SourceCode> readAllByIsActive(boolean isActive) {
 		return repository.findAllByIsActive(isActive).stream().map(mapper::fromEntity).toList();
 	}
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/PassportStatus.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/PassportStatus.java
@@ -41,6 +41,9 @@ public interface PassportStatus extends AbstractDomainObject {
 	String getManifestNumber();
 
 	@Nullable
+	String getSourceCodeId();
+
+	@Nullable
 	String getSurname();
 
 	@Nullable

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/SourceCode.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/SourceCode.java
@@ -1,0 +1,29 @@
+package ca.gov.dtsstn.passport.api.service.domain;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+import org.immutables.value.Value.Style.ValidationMethod;
+import org.springframework.lang.Nullable;
+
+/**
+ * Domain object that represents an IRCC source system (ex: IRIS, GCMS, Tempo)
+ *
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Immutable
+@Style(validationMethod = ValidationMethod.NONE)
+public interface SourceCode extends AbstractDomainObject {
+
+	@Nullable
+	String getCode();
+
+	@Nullable
+	String getCdoCode();
+
+	@Nullable
+	String getDescription();
+
+	@Nullable
+	Boolean getIsActive();
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/PassportStatusMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/PassportStatusMapper.java
@@ -8,7 +8,6 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.springframework.lang.Nullable;
 
 import ca.gov.dtsstn.passport.api.data.entity.PassportStatusEntity;
-import ca.gov.dtsstn.passport.api.data.entity.SourceCodeEntity;
 import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 
 /**
@@ -16,34 +15,17 @@ import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
  *
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
  */
-@Mapper(componentModel = "spring", uses = { StatusCodeMapper.class })
+@Mapper(componentModel = "spring", uses = { SourceCodeMapper.class, StatusCodeMapper.class })
 public interface PassportStatusMapper {
-
-	/**
-	 * ID of the IRIS source system; see: src/main/resources/db-migrations/common/v3-[common]-add-source-code-table.sql
-	 *
-	 * TODO :: GjB :: remove in future commit
-	 */
-	static final String IRIS_SOURCE_ID = "327c25eb-e3f4-492e-bd47-4feb20189e78";
-
-	/**
-	 * Temporary method that will generate a SourceCodeEntity that maps to IRIS.
-	 *
-	 * TODO :: GjB :: remove this and create an actual mapper in a future commit
-	 */
-	default SourceCodeEntity irisSourceCode() {
-		final var sourceCode = new SourceCodeEntity();
-		sourceCode.setId(IRIS_SOURCE_ID);
-		return sourceCode;
-	}
 
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	@Mapping(target = "sourceCode", expression = "java(irisSourceCode())") // TODO :: GjB :: remove in future commit
+	@Mapping(target = "sourceCode", source = "sourceCodeId")
 	@Mapping(target = "statusCode", source = "statusCodeId")
 	PassportStatusEntity toEntity(@Nullable PassportStatus passportStatus);
 
 	@Nullable
+	@Mapping(target = "sourceCodeId", source = "sourceCode.id")
 	@Mapping(target = "statusCodeId", source = "statusCode.id")
 	PassportStatus fromEntity(@Nullable PassportStatusEntity passportStatus);
 
@@ -53,7 +35,7 @@ public interface PassportStatusMapper {
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
 	@Mapping(target = "isNew", ignore = true)
-	@Mapping(target = "sourceCode", expression = "java(irisSourceCode())") // TODO :: GjB :: remove in future commit
+	@Mapping(target = "sourceCode", source = "sourceCodeId")
 	@Mapping(target = "statusCode", source = "statusCodeId")
 	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 	PassportStatusEntity update(@Nullable PassportStatus passportStatus, @MappingTarget PassportStatusEntity target);

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/SourceCodeMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/SourceCodeMapper.java
@@ -1,0 +1,45 @@
+package ca.gov.dtsstn.passport.api.service.domain.mapper;
+
+import java.util.Optional;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import ca.gov.dtsstn.passport.api.data.entity.SourceCodeEntity;
+import ca.gov.dtsstn.passport.api.service.SourceCodeService;
+import ca.gov.dtsstn.passport.api.service.domain.SourceCode;
+import jakarta.annotation.PostConstruct;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Mapper(componentModel = "spring")
+public abstract class SourceCodeMapper {
+
+	@Autowired
+	protected SourceCodeService sourceCodeService;
+
+	@PostConstruct
+	public void postConstruct() {
+		Assert.notNull(sourceCodeService, "sourceCodeService is required; it must not be null");
+	}
+
+	@Nullable
+	public SourceCodeEntity fromId(@Nullable String id) {
+		return Optional.ofNullable(id)
+			.flatMap(sourceCodeService::read)
+			.map(this::toEntity)
+			.orElse(null);
+	}
+
+	@Nullable
+	public abstract SourceCode fromEntity(@Nullable SourceCodeEntity sourceCode);
+
+	@Nullable
+	@Mapping(target = "isNew", ignore = true)
+	public abstract SourceCodeEntity toEntity(@Nullable SourceCode sourceCode);
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/StatusCodeMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/domain/mapper/StatusCodeMapper.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -37,10 +36,10 @@ public abstract class StatusCodeMapper {
 	}
 
 	@Nullable
-	public abstract StatusCode fromEntity(@Nullable StatusCodeEntity passportStatus);
+	public abstract StatusCode fromEntity(@Nullable StatusCodeEntity statusCode);
 
 	@Nullable
 	@Mapping(target = "isNew", ignore = true)
-	public abstract StatusCodeEntity toEntity(@Nullable StatusCode passportStatus);
+	public abstract StatusCodeEntity toEntity(@Nullable StatusCode statusCode);
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapper.java
@@ -55,6 +55,7 @@ public abstract class CertificateApplicationModelMapper {
 	@Mapping(target = "givenName", source = "certificateApplication.certificateApplicationApplicant.personName.personGivenNames", qualifiedByName = { "getFirstElement" })
 	@Mapping(target = "manifestNumber", source = "certificateApplication.certificateApplicationIdentifications", qualifiedByName = { "findManifestNumber" })
 	@Mapping(target = "surname", source = "certificateApplication.certificateApplicationApplicant.personName.personSurname")
+	@Mapping(target = "sourceCodeId", ignore = true) // TODO :: GjB :: remove this when exposing source field in API models
 	@Mapping(target = "statusCodeId", source = "certificateApplication.certificateApplicationStatus", qualifiedByName = { "toStatusCodeId" })
 	@Mapping(target = "statusDate", source = "certificateApplication.certificateApplicationStatus.statusDate.date")
 	@Mapping(target = "version", source = "certificateApplication.resourceMeta.version")

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/ElectronicServiceRequestModelMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/ElectronicServiceRequestModelMapper.java
@@ -27,6 +27,7 @@ public interface ElectronicServiceRequestModelMapper {
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
 	@Mapping(target = "manifestNumber", ignore = true)
+	@Mapping(target = "sourceCodeId", ignore = true) // TODO :: GjB :: remove this when exposing source field in API models
 	@Mapping(target = "statusCodeId", ignore = true)
 	@Mapping(target = "statusDate", ignore = true)
 	@Mapping(target = "dateOfBirth", source = "client.personBirthDate.date")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -173,6 +173,9 @@ application:
       esrf-emails:
         expire-after-write: 1
         time-unit: minutes
+      source-codes:
+        expire-after-write: 5
+        time-unit: minutes
       status-codes:
         expire-after-write: 5
         time-unit: minutes


### PR DESCRIPTION
- Add service layer DTO for `SourceCode` and the associated spring cache configs
- Add `SourceCode` DTO → entity mapper and service class
- Update `PassportStatusService` to set default source to IRIS (to be removed in future commit)
- Fixup data layer to remove defaults (see previous point)