### PR TITLE
Add source code field to NIEM models

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/service/PassportStatusService.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/PassportStatusService.java
@@ -16,7 +16,6 @@ import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusCreatedEvent;
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusDeletedEvent;
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusReadEvent;
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusUpdatedEvent;
-import ca.gov.dtsstn.passport.api.service.domain.ImmutablePassportStatus;
 import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 import ca.gov.dtsstn.passport.api.service.domain.mapper.PassportStatusMapper;
 
@@ -27,8 +26,6 @@ import ca.gov.dtsstn.passport.api.service.domain.mapper.PassportStatusMapper;
  */
 @Service
 public class PassportStatusService {
-
-	private static final String IRIS_ID = "327c25eb-e3f4-492e-bd47-4feb20189e78";
 
 	private final ApplicationEventPublisher eventPublisher;
 
@@ -55,10 +52,7 @@ public class PassportStatusService {
 			return existingPassportStatus.get();
 		}
 
-		// TODO :: GjB :: remove this when exposing source field in API models
-		final var tmpPassportStatus = ImmutablePassportStatus.copyOf(passportStatus).withSourceCodeId(IRIS_ID);
-
-		final var createdPassportStatus = mapper.fromEntity(repository.save(mapper.toEntity(tmpPassportStatus))); // NOSONAR (nullable param)
+		final var createdPassportStatus = mapper.fromEntity(repository.save(mapper.toEntity(passportStatus))); // NOSONAR (nullable param)
 		eventPublisher.publishEvent(ImmutablePassportStatusCreatedEvent.of(createdPassportStatus));
 		return createdPassportStatus;
 	}
@@ -74,11 +68,7 @@ public class PassportStatusService {
 		Assert.notNull(passportStatus, "passportStatus is required; it must not be null");
 		Assert.notNull(passportStatus.getId(), "passportStatus.id must not be null when updating existing instance");
 		final var originalPassportStatus = repository.findById(passportStatus.getId()).orElseThrow(); // NOSONAR (nullable param)
-
-		// TODO :: GjB :: remove this when exposing source field in API models
-		final var tmpPassportStatus = ImmutablePassportStatus.copyOf(passportStatus).withSourceCodeId(IRIS_ID);
-
-		final var updatedPassportStatus = mapper.fromEntity(repository.save(mapper.update(tmpPassportStatus, originalPassportStatus)));
+		final var updatedPassportStatus = mapper.fromEntity(repository.save(mapper.update(passportStatus, originalPassportStatus)));
 		eventPublisher.publishEvent(ImmutablePassportStatusUpdatedEvent.of(mapper.fromEntity(originalPassportStatus), updatedPassportStatus));
 		return updatedPassportStatus;
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/ResourceMetaModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/ResourceMetaModel.java
@@ -2,6 +2,7 @@ package ca.gov.dtsstn.passport.api.web.model;
 
 import java.io.Serializable;
 
+import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
@@ -10,8 +11,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
@@ -27,5 +30,13 @@ public interface ResourceMetaModel extends Serializable {
 	@Digits(message = "VersionID must be a numeric string", integer = 16, fraction = 0)
 	@Schema(description = "The version of the resource content. Can be used to ensure that updates are based on the latest version of the resource.", example = "0000")
 	String getVersion();
+
+	@Valid
+	@Default
+	@JsonProperty("SourceCode")
+	@NotNull(message = "SourceCode is required; it must not be null")
+	default  SourceCodeModel getSourceCode() {
+		return ImmutableSourceCodeModel.builder().build();
+	}
 
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/SourceCodeModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/SourceCodeModel.java
@@ -1,0 +1,31 @@
+package ca.gov.dtsstn.passport.api.web.model;
+
+import java.io.Serializable;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+import org.immutables.value.Value.Style.ValidationMethod;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import ca.gov.dtsstn.passport.api.web.validation.ReferenceDataId;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Immutable
+@Schema(name = "SourceCode")
+@Style(validationMethod = ValidationMethod.NONE)
+@JsonDeserialize(as = ImmutableSourceCodeModel.class)
+public interface SourceCodeModel extends Serializable {
+
+	@JsonProperty("ReferenceDataID")
+	@ReferenceDataId(message = "ReferenceDataID is invalid or unknown")
+	@NotBlank(message = "ReferenceDataID is required; it must not be null or blank")
+	@Schema(description = "The source ID of the certificate application data.", example = "33")
+	String getReferenceDataId();
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/ElectronicServiceRequestModelMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/ElectronicServiceRequestModelMapper.java
@@ -27,7 +27,7 @@ public interface ElectronicServiceRequestModelMapper {
 	@Mapping(target = "lastModifiedBy", ignore = true)
 	@Mapping(target = "lastModifiedDate", ignore = true)
 	@Mapping(target = "manifestNumber", ignore = true)
-	@Mapping(target = "sourceCodeId", ignore = true) // TODO :: GjB :: remove this when exposing source field in API models
+	@Mapping(target = "sourceCodeId", ignore = true)
 	@Mapping(target = "statusCodeId", ignore = true)
 	@Mapping(target = "statusDate", ignore = true)
 	@Mapping(target = "dateOfBirth", source = "client.personBirthDate.date")

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ReferenceDataId.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ReferenceDataId.java
@@ -1,0 +1,25 @@
+package ca.gov.dtsstn.passport.api.web.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ReferenceDataIdValidator.class)
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE_USE })
+public @interface ReferenceDataId {
+
+	String message();
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ReferenceDataIdValidator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/validation/ReferenceDataIdValidator.java
@@ -1,0 +1,36 @@
+package ca.gov.dtsstn.passport.api.web.validation;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import ca.gov.dtsstn.passport.api.service.SourceCodeService;
+import ca.gov.dtsstn.passport.api.service.domain.SourceCode;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Checks that a string is a reference data ID.
+ *
+ * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
+ */
+@Component
+public class ReferenceDataIdValidator implements ConstraintValidator<ReferenceDataId, String> {
+
+	private final SourceCodeService sourceCodeService;
+
+	public ReferenceDataIdValidator(SourceCodeService sourceCodeService) {
+		Assert.notNull(sourceCodeService, "sourceCodeService is required; it must not be null");
+		this.sourceCodeService = sourceCodeService;
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null) { return true;}
+
+		return sourceCodeService.readByCdoCode(value)
+			.map(SourceCode::getIsActive)
+			.filter(Boolean.TRUE::equals)
+			.isPresent();
+	}
+
+}

--- a/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
@@ -16,9 +16,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import ca.gov.dtsstn.passport.api.service.SourceCodeService;
 import ca.gov.dtsstn.passport.api.service.StatusCodeService;
 import ca.gov.dtsstn.passport.api.service.domain.ImmutablePassportStatus;
 import ca.gov.dtsstn.passport.api.service.domain.ImmutableStatusCode;
@@ -49,11 +51,15 @@ class CertificateApplicationModelMapperTests {
 	CertificateApplicationModelMapper mapper = Mappers.getMapper(CertificateApplicationModelMapper.class);
 
 	@Mock
-  	private StatusCodeService statusCodeService;
+	private SourceCodeService sourceCodeService;
+
+	@Mock
+	private StatusCodeService statusCodeService;
 
 	@BeforeEach
 	void setUp() {
-		mapper.setStatusCodeService(statusCodeService);
+		ReflectionTestUtils.setField(mapper, "sourceCodeService", sourceCodeService);
+		ReflectionTestUtils.setField(mapper, "statusCodeService", statusCodeService);
 	}
 
 	@Test
@@ -178,7 +184,7 @@ class CertificateApplicationModelMapperTests {
 
 	@Test
 	void testToModel_null() {
-		assertThat(mapper.toModel(null)).isEqualTo(null);
+		assertThat(mapper.toModel(null)).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
- Remove defaulting to IRIS source in service layer
- Add `CertificateApplication.ResourceMeta.SourceCode.ReferenceDataID` field to REST models
- Add `ReferenceDataIdValidator`
- Fix broken tests