### PR TITLE
Add search result data to search events

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/event/PassportStatusSearchEvent.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/event/PassportStatusSearchEvent.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value.Immutable;
 import org.springframework.lang.Nullable;
 
 import ca.gov.dtsstn.passport.api.event.ImmutablePassportStatusSearchEvent.Builder;
+import ca.gov.dtsstn.passport.api.service.domain.PassportStatus;
 
 /**
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
@@ -21,6 +22,9 @@ public interface PassportStatusSearchEvent extends Serializable {
 	static Builder builder() {
 		return ImmutablePassportStatusSearchEvent.builder();
 	}
+
+	@Nullable
+	Iterable<String> getApplicationRegisterSids();
 
 	@Nullable
 	LocalDate getDateOfBirth();
@@ -38,6 +42,9 @@ public interface PassportStatusSearchEvent extends Serializable {
 	String getSurname();
 
 	Result getResult();
+
+	@Nullable
+	PassportStatus getPassportStatus();
 
 	@Default
 	default Instant getTimestamp() {


### PR DESCRIPTION
## Summary

Added additional audit data to `PassportStatusSearchEvent`: `applicationRegisterSids` and `passportStatus`. These fields are marked as `@Nullable`, meaning they may be null, depending on the search result (hit, miss, non-unique).

## Examples

### SEARCH_STATUS_MISS

``` json
{
  "applicationRegisterSids": null,
  "dateOfBirth": "2000-01-01",
  "email": null,
  "fileNumber": "D120DE30",
  "givenName": "Goober",
  "surname": "Baker",
  "result": "MISS",
  "passportStatus": null,
  "timestamp": "2023-06-08T10:34:54.179142057Z"
}
```

### SEARCH_STATUS_NON_UNIQUE

Notice the new `applicationRegisterSids` field which displays the SIDs of the matching passport statuses.

``` json
{
  "applicationRegisterSids": [
    "ab15c32d-961e-3895-ba8a-9e4c26ccadf5",
    "3186356f-eb4a-4f8a-9603-cbb391355ca4"
  ],
  "dateOfBirth": "2000-01-01",
  "email": null,
  "fileNumber": "D120DE30",
  "givenName": "Greg",
  "surname": "Baker",
  "result": "NON_UNIQUE",
  "passportStatus": null,
  "timestamp": "2023-06-08T10:34:10.550373200Z"
}
```

### SEARCH_STATUS_HIT

Notice the new `passportStatus` field which shows the status object that will be returned to the API consumer.

``` json
{
  "applicationRegisterSids": null,
  "dateOfBirth": "2000-01-01",
  "email": null,
  "fileNumber": "D120DE30",
  "givenName": "Greg",
  "surname": "Baker",
  "result": "HIT",
  "passportStatus": {
    "id": "0f4bab23-dbba-3406-972f-a2a9526c8150",
    "createdBy": "Passport Status API",
    "createdDate": "2023-06-08T07:56:57.519941Z",
    "lastModifiedBy": "Passport Status API",
    "lastModifiedDate": "2023-06-08T07:56:57.519941Z",
    "applicationRegisterSid": "ab15c32d-961e-3895-ba8a-9e4c26ccadf5",
    "dateOfBirth": "2000-01-01",
    "email": "gregory.j.baker@hrsdc-rhdcc.gc.ca",
    "fileNumber": "D120DE30",
    "givenName": "Greg",
    "manifestNumber": "400ECD9F",
    "sourceCodeId": "327c25eb-e3f4-492e-bd47-4feb20189e78",
    "surname": "Baker",
    "statusCodeId": "af0857c3-467a-4770-9b2b-964f1d252107",
    "statusDate": "1999-12-31",
    "version": 32032
  },
  "timestamp": "2023-06-08T10:28:08.196404855Z"
}
```
### ---

![image](https://github.com/DTS-STN/passport-status-api/assets/48123208/24ad914c-507c-4fbf-8e9f-5835f677808c)
