### PR TITLE
Fix warning in UuidGenerator; improve test

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/data/UuidGenerator.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/UuidGenerator.java
@@ -21,6 +21,7 @@ import org.hibernate.id.IdentifierGenerator;
  *
  * @author Greg Baker (gregory.j.baker@hrsdc-rhdcc.gc.ca)
  */
+@SuppressWarnings({ "serial" })
 public class UuidGenerator implements IdentifierGenerator {
 
 	private final transient ValueGenerator valueGenerator;

--- a/src/test/java/ca/gov/dtsstn/passport/api/data/UuidGeneratorTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/data/UuidGeneratorTests.java
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.when;
 import java.util.UUID;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.EventType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,30 +22,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith({ MockitoExtension.class })
 class UuidGeneratorTests {
 
-	@Mock UuidGenerator.ValueGenerator valueGenerator;
-
 	UuidGenerator uuidGenerator;
 
 	final UUID id = UUID.randomUUID();
 
 	@BeforeEach
 	void setUp() {
-		this.uuidGenerator = new UuidGenerator(valueGenerator);
+		this.uuidGenerator = new UuidGenerator(() -> id);
 	}
 
 	@Test
 	void testGenerate_withId() {
 		final SharedSessionContractImplementor sharedSessionContractImplementor = mock(SharedSessionContractImplementor.class, Mockito.RETURNS_DEEP_STUBS);
 		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(id.toString());
-		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, new Object())).asString().isEqualTo(id.toString());
+		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, null, new Object(), EventType.INSERT)).asString().isEqualTo(id.toString());
 	}
 
 	@Test
 	void testGenerate_withNullId() {
 		final SharedSessionContractImplementor sharedSessionContractImplementor = mock(SharedSessionContractImplementor.class, Mockito.RETURNS_DEEP_STUBS);
 		when(sharedSessionContractImplementor.getEntityPersister(any(), any()).getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(null);
-		when(valueGenerator.generateUuid()).thenReturn(id);
-		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, new Object())).asString().isEqualTo(id.toString());
+		assertThat(uuidGenerator.generate(sharedSessionContractImplementor, null, new Object(), EventType.INSERT)).asString().isEqualTo(id.toString());
 	}
 
 }


### PR DESCRIPTION
The new version of hibernate used in Spring Boot 3.1.x caused a serialization warning in `UuidGenerator`. The tests also needed some love.