### PR TITLE
Remove dependency-check-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,12 @@
 		<!-- dependency/plugin versions -->
 
 		<datafaker.version>2.0.2</datafaker.version>
-		<dependency-check-maven.version>8.4.0</dependency-check-maven.version>
 		<duplicate-finder-maven-plugin.version>2.0.1</duplicate-finder-maven-plugin.version>
 		<gitlog-maven-plugin.version>1.14.0</gitlog-maven-plugin.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<icu4j.version>74.1</icu4j.version>
 		<immutables.version>2.10.0</immutables.version>
 		<mapstruct.version>1.5.5.Final</mapstruct.version>
-		<snakeyaml.version>2.0</snakeyaml.version><!-- https://www.cve.org/CVERecord?id=CVE-2022-1471 -->
 		<spring-boot-configuration-processor.version>3.2.0</spring-boot-configuration-processor.version>
 		<springdoc.version>2.2.0</springdoc.version>
 	</properties>
@@ -288,24 +286,6 @@
 				<groupId>org.basepom.maven</groupId>
 				<artifactId>duplicate-finder-maven-plugin</artifactId>
 				<version>${duplicate-finder-maven-plugin.version}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.owasp</groupId>
-				<artifactId>dependency-check-maven</artifactId>
-				<version>${dependency-check-maven.version}</version>
-				<configuration>
-					<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-					<failOnError>false</failOnError>
-					<nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
-					<nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
We've decided to remove that plugin since the reports not being use or read. It is also requires to update it to version 9 and it add some complexity like the need to use an API key to fetch the database faster.

https://github.com/jeremylong/DependencyCheck#900-upgrade-notice