### PR TITLE
Add flyway-database-postgresql dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
 			<artifactId>flyway-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.immutables</groupId>
 			<artifactId>annotate</artifactId>
 			<version>${immutables.version}</version>


### PR DESCRIPTION
Added postgresql flyway support.

Modular Flyway V10 (No database found to handle or Unsupported Database)

https://github.com/flyway/flyway/issues/3780