### PR TITLE
Add feature-flag for hiding manifest numbers

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/ApplicationProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/ApplicationProperties.java
@@ -11,12 +11,14 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @ConfigurationProperties("application")
 @EnableConfigurationProperties({
+	FeatureFlagsProperties.class,
 	GcNotifyProperties.class,
 	JmsProperties.class,
 	SecurityProperties.class,
 	SwaggerUiProperties.class
 })
 public record ApplicationProperties(
+	@NestedConfigurationProperty FeatureFlagsProperties featureFlags,
 	@NestedConfigurationProperty GcNotifyProperties gcnotify,
 	@NestedConfigurationProperty JmsProperties jms,
 	@NestedConfigurationProperty SecurityProperties security,

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/FeatureFlagsProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/FeatureFlagsProperties.java
@@ -1,0 +1,21 @@
+package ca.gov.dtsstn.passport.api.config.properties;
+
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Ken Blanchard (ken.blanchard@hrsdc-rhdcc.gc.ca)
+ */
+@ConfigurationProperties("application.feature-flags")
+public class FeatureFlagsProperties {
+	private Map<String, Boolean> hideManifest = Map.of();
+
+  public Map<String, Boolean> getHideManifest() {
+      return hideManifest;
+  }
+
+  public void setHideManifest(Map<String, Boolean> map) {
+      this.hideManifest = map;
+  }
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/FeatureFlagsProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/FeatureFlagsProperties.java
@@ -1,21 +1,21 @@
 package ca.gov.dtsstn.passport.api.config.properties;
 
-import java.util.Map;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
 
 /**
  * @author Ken Blanchard (ken.blanchard@hrsdc-rhdcc.gc.ca)
  */
 @ConfigurationProperties("application.feature-flags")
 public class FeatureFlagsProperties {
-	private Map<String, Boolean> hideManifest = Map.of();
+	private List<String> hiddenManifests = List.of();
 
-  public Map<String, Boolean> getHideManifest() {
-      return hideManifest;
+  public List<String> getHiddenManifests() {
+      return hiddenManifests;
   }
 
-  public void setHideManifest(Map<String, Boolean> map) {
-      this.hideManifest = map;
+  public void setHiddenManifests(List<String> list) {
+      this.hiddenManifests = list;
   }
 }

--- a/src/main/java/ca/gov/dtsstn/passport/api/config/properties/HideManifestProperties.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/config/properties/HideManifestProperties.java
@@ -1,0 +1,25 @@
+package ca.gov.dtsstn.passport.api.config.properties;
+
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for hiding the manifest numbers from client/public view.
+ * 
+ * Mapping of status code to boolean value.
+ *
+ * @author Ken Blanchard (ken.blanchard@hrsdc-rhdcc.gc.ca)
+ */
+@ConfigurationProperties("application.feature-flags.hide-manifest")
+public class HideManifestProperties {
+  private Map<String, Boolean> map;
+
+  public Map<String, Boolean> getMap() {
+      return map;
+  }
+
+  public void setMap(Map<String, Boolean> map) {
+      this.map = map;
+  }
+}

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/StatusCodeEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/StatusCodeEntity.java
@@ -16,7 +16,7 @@ import jakarta.persistence.Entity;
 @Entity(name = "StatusCode")
 public class StatusCodeEntity extends AbstractEntity {
 
-	@Column(length = 16, nullable = false)
+	@Column(length = 64, nullable = false)
 	private String code;
 
 	@Column(length = 8, nullable = false)

--- a/src/main/resources/application-local.yaml.sample
+++ b/src/main/resources/application-local.yaml.sample
@@ -26,9 +26,8 @@ application:
   database-initializer:
     run-on-startup: true
   feature-flags:
-    hide-manifest: # Map of status codes to boolean values. Default is false.
-      'PASSPORT_ISSUED_SHIPPING_CANADA_POST': true
-      'PASSPORT_ISSUED_SHIPPING_FEDEX': false
+    # List of statuses, whose manifests should not be sent to the client.
+    hidden-manifests: ['PASSPORT_ISSUED_SHIPPING_CANADA_POST'] 
   gcnotify:
     english-api-key: gcntfy-project-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000
     french-api-key: gcntfy-project-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000

--- a/src/main/resources/application-local.yaml.sample
+++ b/src/main/resources/application-local.yaml.sample
@@ -25,6 +25,10 @@ spring:
 application:
   database-initializer:
     run-on-startup: true
+  feature-flags:
+    hide-manifest: # Map of status codes to boolean values. Default is false.
+      'PASSPORT_ISSUED_SHIPPING_CANADA_POST': true
+      'PASSPORT_ISSUED_SHIPPING_FEDEX': false
   gcnotify:
     english-api-key: gcntfy-project-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000
     french-api-key: gcntfy-project-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000

--- a/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
@@ -3,6 +3,7 @@ package ca.gov.dtsstn.passport.api.web.model.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -273,7 +274,7 @@ class CertificateApplicationModelMapperTests {
 			.extracting(StatusDateModel::getDate)
 			.isEqualTo(statusDate.toString());
 
-		verify(statusCodeService).read(any());
+		verify(statusCodeService, times(2)).read(any());
 	}
 
 	@Test


### PR DESCRIPTION
## [ADO-4936](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/4936)

### Description

List of proposed changes:

- Add configuration properties for hiding the manifest numbers from client/public view

### What to test for/How to test

### Additional Notes
