### PR TITLE
Fix broken database initializer and fix deprecations/warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
 		<datafaker.version>2.4.2</datafaker.version>
 		<duplicate-finder-maven-plugin.version>2.0.1</duplicate-finder-maven-plugin.version>
 		<gitlog-maven-plugin.version>1.14.0</gitlog-maven-plugin.version>
-		<guava.version>33.3.1-jre</guava.version>
 		<icu4j.version>76.1</icu4j.version>
 		<immutables.version>2.10.1</immutables.version>
 		<mapstruct.version>1.6.3</mapstruct.version>
@@ -80,7 +79,6 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/annotation/EntityId.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/annotation/EntityId.java
@@ -1,0 +1,15 @@
+package ca.gov.dtsstn.passport.api.data.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.annotations.IdGeneratorType;
+
+import ca.gov.dtsstn.passport.api.data.UuidGenerator;
+
+@Retention(RetentionPolicy.RUNTIME)
+@IdGeneratorType(UuidGenerator.class)
+@Target({ ElementType.FIELD, ElementType.METHOD})
+public @interface EntityId {}

--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/AbstractEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/AbstractEntity.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.hibernate.annotations.GenericGenerator;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,11 +14,10 @@ import org.springframework.data.domain.Persistable;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.lang.Nullable;
 
-import ca.gov.dtsstn.passport.api.data.UuidGenerator;
+import ca.gov.dtsstn.passport.api.data.annotation.EntityId;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Transient;
@@ -42,9 +40,8 @@ import jakarta.persistence.Transient;
 public abstract class AbstractEntity implements Persistable<String>, Serializable {
 
 	@Id
-	@GeneratedValue(generator = "uuid-generator")
+	@EntityId
 	@Column(length = 64, nullable = false, updatable = false)
-	@GenericGenerator(name = "uuid-generator", type = UuidGenerator.class)
 	protected String id;
 
 	@CreatedBy
@@ -141,7 +138,7 @@ public abstract class AbstractEntity implements Persistable<String>, Serializabl
 		if (obj == null) { return false; }
 		if (getClass() != obj.getClass()) { return false; }
 
-		final AbstractEntity other = (AbstractEntity) obj;
+		final var other = (AbstractEntity) obj;
 
 		return Objects.equals(id, other.id);
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/NotificationService.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/NotificationService.java
@@ -56,8 +56,8 @@ public class NotificationService {
 
 		final var restTemplate = restTemplateBuilder
 			.defaultHeader(HttpHeaders.AUTHORIZATION, "ApiKey-v1 %s".formatted(getApiKey(preferredLanguage)))
-			.setConnectTimeout(gcNotifyProperties.connectTimeout())
-			.setReadTimeout(gcNotifyProperties.readTimeout())
+			.connectTimeout(gcNotifyProperties.connectTimeout())
+			.readTimeout(gcNotifyProperties.readTimeout())
 			.build();
 
 		final var email = Optional.ofNullable(passportStatus.getEmail()).orElseThrow(); // Optional<T> keeps sonar happy

--- a/src/test/java/ca/gov/dtsstn/passport/api/WebMvcIT.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/WebMvcIT.java
@@ -7,8 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import ca.gov.dtsstn.passport.api.config.WebMvcConfig;
@@ -24,7 +24,7 @@ class WebMvcIT {
 
 	@Autowired MockMvc mvc;
 
-	@MockBean AuthenticationErrorHandler authenticationErrorController;
+	@MockitoBean AuthenticationErrorHandler authenticationErrorController;
 
 	@Test void testSwaggerRedirect() throws Exception {
 		mvc.perform(get("/"))

--- a/src/test/java/ca/gov/dtsstn/passport/api/web/ElectronicServiceRequestControllerTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/web/ElectronicServiceRequestControllerTests.java
@@ -1,6 +1,7 @@
 package ca.gov.dtsstn.passport.api.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -97,7 +98,7 @@ class ElectronicServiceRequestControllerTests {
 		final var eventCaptor = ArgumentCaptor.forClass(Object.class);
 		verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
 
-		assertThat(eventCaptor).extracting(ArgumentCaptor::getAllValues).asList()
+		assertThat(eventCaptor).extracting(ArgumentCaptor::getAllValues).asInstanceOf(LIST)
 			// verify that the correct event types were fired
 			.anyMatch(event -> ClassUtils.isAssignableValue(NotificationRequestedEvent.class, event))
 			.anyMatch(event -> ClassUtils.isAssignableValue(NotificationNotSentEvent.class, event))
@@ -122,7 +123,7 @@ class ElectronicServiceRequestControllerTests {
 		final var eventCaptor = ArgumentCaptor.forClass(Object.class);
 		verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
 
-		assertThat(eventCaptor).extracting(ArgumentCaptor::getAllValues).asList()
+		assertThat(eventCaptor).extracting(ArgumentCaptor::getAllValues).asInstanceOf(LIST)
 			// verify that the correct event types were fired
 			.anyMatch(event -> ClassUtils.isAssignableValue(NotificationRequestedEvent.class, event))
 			.anyMatch(event -> ClassUtils.isAssignableValue(NotificationNotSentEvent.class, event))
@@ -148,7 +149,7 @@ class ElectronicServiceRequestControllerTests {
 		verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
 
 		// verify that the correct event types were fired
-		assertThat(eventCaptor).extracting(ArgumentCaptor::getAllValues).asList()
+		assertThat(eventCaptor).extracting(ArgumentCaptor::getAllValues).asInstanceOf(LIST)
 			.anyMatch(event -> ClassUtils.isAssignableValue(NotificationRequestedEvent.class, event))
 			.anyMatch(event -> ClassUtils.isAssignableValue(NotificationSentEvent.class, event));
 	}

--- a/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
@@ -2,6 +2,7 @@ package ca.gov.dtsstn.passport.api.web.model.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -232,7 +233,7 @@ class CertificateApplicationModelMapperTests {
 			.isEqualTo(dateOfBirth.toString());
 		assertThat(getCertificateApplicationRepresentation) // check applicationRegisterSid field
 			.extracting(GetCertificateApplicationRepresentationModel::getCertificateApplication)
-			.extracting(CertificateApplicationModel::getCertificateApplicationIdentifications).asList()
+			.extracting(CertificateApplicationModel::getCertificateApplicationIdentifications).asInstanceOf(LIST)
 			.contains(ImmutableCertificateApplicationIdentificationModel.builder()
 				.identificationCategoryText(CertificateApplicationIdentificationModel.APPLICATION_REGISTER_SID_CATEGORY_TEXT)
 				.identificationId(applicationRegisterSid)
@@ -245,7 +246,7 @@ class CertificateApplicationModelMapperTests {
 			.isEqualTo(email);
 		assertThat(getCertificateApplicationRepresentation) // check fileNumber field
 			.extracting(GetCertificateApplicationRepresentationModel::getCertificateApplication)
-			.extracting(CertificateApplicationModel::getCertificateApplicationIdentifications).asList()
+			.extracting(CertificateApplicationModel::getCertificateApplicationIdentifications).asInstanceOf(LIST)
 			.contains(ImmutableCertificateApplicationIdentificationModel.builder()
 				.identificationCategoryText(CertificateApplicationIdentificationModel.FILE_NUMBER_CATEGORY_TEXT)
 				.identificationId(fileNumber)
@@ -254,7 +255,7 @@ class CertificateApplicationModelMapperTests {
 			.extracting(GetCertificateApplicationRepresentationModel::getCertificateApplication)
 			.extracting(CertificateApplicationModel::getCertificateApplicationApplicant)
 			.extracting(CertificateApplicationApplicantModel::getPersonName)
-			.extracting(PersonNameModel::getPersonGivenNames).asList()
+			.extracting(PersonNameModel::getPersonGivenNames).asInstanceOf(LIST)
 			.contains(givenName);
 		assertThat(getCertificateApplicationRepresentation) // check surname field
 			.extracting(GetCertificateApplicationRepresentationModel::getCertificateApplication)
@@ -289,7 +290,7 @@ class CertificateApplicationModelMapperTests {
 		final var objectMapper = new ObjectMapper().findAndRegisterModules();
 
 		// cheating a little here because doing anything with NIEM sucks.. 😳
-		final String json = """
+		final var json = """
 			{
 			  "CertificateApplication": {
 			    "CertificateApplicationApplicant": {


### PR DESCRIPTION
Things that have changed:
  - datafaker deprecated its `DataAndTime` provider, creating a new `TimeAndDate` provider based off the `java.time.*` API
  - Hibernate has changed how ID generation works and now you can no longer pre-calculate IDs before persisting a new entity (at least, I couldn't figure out how)