### PR TITLE
Make 'givenName' nullable for intake

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/data/entity/PassportStatusEntity.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/entity/PassportStatusEntity.java
@@ -31,7 +31,7 @@ public class PassportStatusEntity extends AbstractEntity {
 	@Column(length = 32, nullable = false)
 	private String fileNumber;
 
-	@Column(length = 64, nullable = false)
+	@Column(length = 64, nullable = true)
 	private String givenName;
 
 	@Column(length = 32, nullable = true)

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonNameModel.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/PersonNameModel.java
@@ -8,13 +8,15 @@ import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Style.ValidationMethod;
+import org.springframework.lang.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 /**
@@ -26,14 +28,12 @@ import jakarta.validation.constraints.Size;
 @JsonDeserialize(as = ImmutablePersonNameModel.class)
 public interface PersonNameModel extends Serializable {
 
-	@Default
 	@JsonProperty("PersonGivenName")
-	@NotNull(message = "PersonGivenName is required; it must not be null")
+	@Nullable
+	@JsonSetter(nulls = Nulls.SKIP)
 	@Size(min = 1, max = 1, message = "PersonGivenName must be an array of size 1")
-	@Schema(description = "A set of given names of the certificate applicant.", example = "[\"John\"]")
-	default List<@NotBlank(message = "PersonGivenName is required; it must not be null or blank") @Size(max = 128, message = "PersonGivenName must be 128 characters or less") String> getPersonGivenNames() {
-		return Collections.emptyList();
-	}
+	@Schema(description = "A set of given names of the certificate applicant. May be null, but if present must contain exactly one non-blank entry.", example = "[\"John\"]")
+	List<@NotBlank(message = "PersonGivenName entries must not be blank") @Size(max = 128, message = "PersonGivenName must be 128 characters or less") String> getPersonGivenNames();
 
 	@JsonProperty("PersonSurName")
 	@Size(max = 128, message = "PersonSurName must be 128 characters or less")

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapper.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapper.java
@@ -293,7 +293,7 @@ public abstract class CertificateApplicationModelMapper {
 		return Optional.ofNullable(passportStatus)
 			.map(PassportStatus::getGivenName)
 			.map(List::of)
-			.orElse(List.of());
+			.orElse(null);
 	}
 
 	/**

--- a/src/main/resources/db-migrations/common/v8-[common]-given-name-nullable.sql
+++ b/src/main/resources/db-migrations/common/v8-[common]-given-name-nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE passport_status
+ALTER COLUMN given_name DROP NOT NULL;

--- a/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/web/model/mapper/CertificateApplicationModelMapperTests.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -163,6 +162,11 @@ class CertificateApplicationModelMapperTests {
 				.identificationId(fileNumber)
 				.build())))
 			.isEqualTo(fileNumber);
+	}
+
+	@Test
+	void testGetPersonGivenNames_null() {
+		assertThat(mapper.getPersonGivenNames(null)).isNull();
 	}
 
 	@Test
@@ -336,6 +340,32 @@ class CertificateApplicationModelMapperTests {
 	}
 
 	@Test
+	void testToModel_singleName() {
+		final String givenName = null;
+		final var surname = "https://open.spotify.com/track/5uFQgThuwbNhFItxJczUgv";
+
+		final var passportStatus = ImmutablePassportStatus.builder()
+			.givenName(givenName)
+			.surname(surname)
+			.build();
+
+		final var getCertificateApplicationRepresentation = mapper.toModel(passportStatus);
+
+		assertThat(getCertificateApplicationRepresentation) // check givenName field
+			.extracting(GetCertificateApplicationRepresentationModel::getCertificateApplication)
+			.extracting(CertificateApplicationModel::getCertificateApplicationApplicant)
+			.extracting(CertificateApplicationApplicantModel::getPersonName)
+			.extracting(PersonNameModel::getPersonGivenNames)
+			.isNull();
+		assertThat(getCertificateApplicationRepresentation) // check surname field
+			.extracting(GetCertificateApplicationRepresentationModel::getCertificateApplication)
+			.extracting(CertificateApplicationModel::getCertificateApplicationApplicant)
+			.extracting(CertificateApplicationApplicantModel::getPersonName)
+			.extracting(PersonNameModel::getPersonSurname)
+			.isEqualTo(surname);
+	}
+
+	@Test
 	void testToDomain_null() throws Exception {
 		assertThat(mapper.toDomain(null)).isNull();
 	}
@@ -447,6 +477,74 @@ class CertificateApplicationModelMapperTests {
 		verify(statusCodeService).readByCdoCode(any());
     verify(deliveryMethodCodeService).readByCdoCode(any());
     verify(serviceLevelCodeService).readByCdoCode(any());
+	}
+
+	@Test
+	void testToDomain_singleName() throws Exception {
+		when(statusCodeService.readByCdoCode(any())).thenReturn(Optional.ofNullable(ImmutableStatusCode.builder().id(STATUS_CODE__FILE_BEING_PROCESSED__ID).build()));
+
+    when(deliveryMethodCodeService.readByCdoCode(any())).thenReturn(Optional.ofNullable(ImmutableDeliveryMethodCode.builder().id(DELIVERY_METHOD_CODE__MAIL__ID).build()));
+
+    when(serviceLevelCodeService.readByCdoCode(any())).thenReturn(Optional.ofNullable(ImmutableServiceLevelCode.builder().id(SERVICE_LEVEL_CODE__TEN_DAYS__ID).build()));
+
+		final var objectMapper = new ObjectMapper().findAndRegisterModules();
+
+		// cheating a little here because doing anything with NIEM sucks.. 😳
+		final var json = """
+			{
+			  "CertificateApplication": {
+			    "CertificateApplicationApplicant": {
+			      "BirthDate": { "Date": "2000-01-01" },
+			      "PersonContactInformation": { "ContactEmailID": "user@example.com" },
+			      "PersonName": {
+			        "PersonSurName": "Doe"
+			      }
+			    },
+			    "CertificateApplicationIdentification": [{
+			      "IdentificationCategoryText": "Application Register SID",
+			      "IdentificationID": "ABCD1234"
+			    }, {
+			      "IdentificationCategoryText": "File Number",
+			      "IdentificationID": "ABCD1234"
+			    }],
+			    "CertificateApplicationStatus": {
+			      "StatusCode": "%s",
+			      "StatusDate": "2000-01-01"
+			    },
+          "CertificateApplicationDeliveryMethod": {
+			      "DeliveryMethodCode": "%s"
+			    },
+          "CertificateApplicationServiceLevel": {
+			      "ServiceLevelCode": "%s"
+			    },
+          "CertificateApplicationTimelineDates": [
+            {
+              "ReferenceDataName": "Received",
+              "TimelineDate": {
+                "Date": "2021-01-01"
+              }
+            }, 
+            {
+              "ReferenceDataName": "Reviewed",
+              "TimelineDate": {
+                "Date": "2021-01-02"
+              }
+            }
+          ]
+			  }
+			}
+		""".formatted(STATUS_CODE__FILE_BEING_PROCESSED__CDO_CODE, DELIVERY_METHOD_CODE__MAIL__ID, SERVICE_LEVEL_CODE__TEN_DAYS__ID);
+
+		final var createCertificateApplicationRequest = objectMapper.readValue(json, CreateCertificateApplicationRequestModel.class);
+
+		final var passportStatus = mapper.toDomain(createCertificateApplicationRequest);
+
+		assertThat(passportStatus)
+			.extracting(PassportStatus::getGivenName)
+			.isNull();
+		assertThat(passportStatus)
+			.extracting(PassportStatus::getSurname)
+			.isEqualTo("Doe");
 	}
 
 	@Test


### PR DESCRIPTION
Make 'givenName' nullable in PassportStatusEntity and update related SQL migration; adjust PersonNameModel and CertificateApplicationModelMapper to handle null values appropriately

```
  "CertificateApplication": {
    "CertificateApplicationApplicant": {
      "BirthDate": {
        "Date": "2000-01-01"
      },
      "PersonContactInformation": {
        "ContactEmailID": "user@example.com"
      },
      "PersonName": {
        "PersonGivenName": [
          "John"
        ],
        "PersonSurName": "Doe"
      }
    },
```
VS.
```
  "CertificateApplication": {
    "CertificateApplicationApplicant": {
      "BirthDate": {
        "Date": "2000-01-01"
      },
      "PersonContactInformation": {
        "ContactEmailID": "user@example.com"
      },
      "PersonName": {
        "PersonSurName": "Doe"
      }
    },
 ```