### PR TITLE
Add endpoint for single-name search

### DIFF
--- a/src/main/java/ca/gov/dtsstn/passport/api/data/PassportStatusRepository.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/data/PassportStatusRepository.java
@@ -20,7 +20,7 @@ public interface PassportStatusRepository extends JpaRepository<PassportStatusEn
 		 WHERE lower(email) = lower(?1)
 		   AND dateOfBirth = ?2
 		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(givenName)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?3)) as string))
-		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname))   as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?4)) as string))
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?4)) as string))
 		   AND version = (SELECT max(version) FROM PassportStatus other WHERE other.applicationRegisterSid = ps.applicationRegisterSid)
 	""")
 	List<PassportStatusEntity> emailSearch(String email, LocalDate dateOfBirth, String givenName, String surname);
@@ -30,10 +30,20 @@ public interface PassportStatusRepository extends JpaRepository<PassportStatusEn
 		 WHERE lower(fileNumber) = lower(?1)
 		   AND dateOfBirth = ?2
 		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(givenName)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?3)) as string))
-		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname))   as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?4)) as string))
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?4)) as string))
 		   AND version = (SELECT MAX(version) FROM PassportStatus other WHERE other.applicationRegisterSid = ps.applicationRegisterSid)
 	""")
 	List<PassportStatusEntity> fileNumberSearch(String fileNumber, LocalDate dateOfBirth, String givenName, String surname);
+
+	@Query("""
+		SELECT ps FROM PassportStatus ps
+		 WHERE lower(fileNumber) = lower(?1)
+		   AND dateOfBirth = ?2
+		   AND ps.givenName IS NULL
+		   AND lower(cast(remove_non_alpha_numeric(remove_diacritics(surname)) as string)) = lower(cast(remove_non_alpha_numeric(remove_diacritics(?3)) as string))
+		   AND version = (SELECT MAX(version) FROM PassportStatus other WHERE other.applicationRegisterSid = ps.applicationRegisterSid)
+	""")
+	List<PassportStatusEntity> fileNumberSearchSingleName(String fileNumber, LocalDate dateOfBirth, String singleName);
 
 	List<PassportStatusEntity> findAllByApplicationRegisterSid(String applicationRegisterSid);
 

--- a/src/main/java/ca/gov/dtsstn/passport/api/service/PassportStatusService.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/service/PassportStatusService.java
@@ -111,7 +111,29 @@ public class PassportStatusService {
 		Assert.hasText(fileNumber, "fileNumber is required; it must not be blank or null");
 		Assert.hasText(givenName, "givenName is required, it must not be blank or null");
 		Assert.hasText(surname, "surname is required; it must not be blank or null");
+
 		final var passportStatuses = repository.fileNumberSearch(fileNumber, dateOfBirth, givenName, surname).stream().map(mapper::fromEntity).toList();
+
+		passportStatuses.stream().map(ImmutablePassportStatusReadEvent::of).forEach(eventPublisher::publishEvent);
+		return passportStatuses;
+	}
+
+	/**
+	 * Search for passport statuses using email, date of birth, and a single name (surname).
+	 * This method is used for individuals who have a single name without a given name. Given name must be explicitly null in the repository.
+	 *
+	 * @param dateOfBirth The date of birth of the passport applicant.
+	 * @param email The email address of the passport applicant.
+	 * @param singleName The single name (surname) of the passport applicant.
+	 * @return A list of matching PassportStatus instances.
+	 */
+	public List<PassportStatus> fileNumberSearchSingleName(LocalDate dateOfBirth, String fileNumber, String singleName) {
+		Assert.notNull(dateOfBirth, "dateOfBirthis required; it must not be null");
+		Assert.hasText(fileNumber, "fileNumber is required; it must not be blank or null");
+		Assert.hasText(singleName, "singleName is required; it must not be blank or null");
+
+		final var passportStatuses = repository.fileNumberSearchSingleName(fileNumber, dateOfBirth, singleName).stream().map(mapper::fromEntity).toList();
+
 		passportStatuses.stream().map(ImmutablePassportStatusReadEvent::of).forEach(eventPublisher::publishEvent);
 		return passportStatuses;
 	}

--- a/src/main/java/ca/gov/dtsstn/passport/api/web/model/assembler/GetCertificateApplicationRepresentationModelAssembler.java
+++ b/src/main/java/ca/gov/dtsstn/passport/api/web/model/assembler/GetCertificateApplicationRepresentationModelAssembler.java
@@ -1,8 +1,5 @@
 package ca.gov.dtsstn.passport.api.web.model.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import java.util.Optional;
 
 import org.springframework.data.web.PagedResourcesAssembler;
@@ -31,16 +28,8 @@ public class GetCertificateApplicationRepresentationModelAssembler extends Abstr
 	protected GetCertificateApplicationRepresentationModel instantiateModel(PassportStatus passportStatus) {
 		Assert.notNull(passportStatus, "passportStatus is required; it must not be null");
 
-		final var dateOfBirth = passportStatus.getDateOfBirth();
-		final var fileNumber = passportStatus.getFileNumber();
-		final var givenName = passportStatus.getGivenName();
-		final var surname = passportStatus.getSurname();
-
-		final var searchLink = linkTo(methodOn(PassportStatusController.class).search(dateOfBirth, fileNumber, givenName, surname, true)).withRel("search");
-
 		return Optional.ofNullable(passportStatus)
-			.map(mapper::toModel).orElseThrow()
-			.add(searchLink);
+			.map(mapper::toModel).orElseThrow();
 	}
 
 }

--- a/src/test/java/ca/gov/dtsstn/passport/api/service/PassportStatusServiceTests.java
+++ b/src/test/java/ca/gov/dtsstn/passport/api/service/PassportStatusServiceTests.java
@@ -156,4 +156,16 @@ class PassportStatusServiceTests {
 		verify(passportStatusMapper).fromEntity(any());
 		verify(applicationEventPublisher).publishEvent(any(PassportStatusReadEvent.class));
 	}
+
+		@Test void testSearchSingleName() {
+		when(passportStatusRepository.fileNumberSearchSingleName(any(), any(), any())).thenReturn(List.of(new PassportStatusEntity()));
+		when(passportStatusMapper.fromEntity(any())).thenReturn(ImmutablePassportStatus.builder().build());
+
+		final var passportStatuses = passportStatusService.fileNumberSearchSingleName(LocalDate.now(), "fileNumber", "singleName");
+
+		assertThat(passportStatuses).isNotNull();
+		verify(passportStatusRepository).fileNumberSearchSingleName(any(), any(), any());
+		verify(passportStatusMapper).fromEntity(any());
+		verify(applicationEventPublisher).publishEvent(any(PassportStatusReadEvent.class));
+	}
 }


### PR DESCRIPTION
Add new passport status controller endpoint to search for 'single name' applications; update related service and repository.

<img width="955" height="51" alt="image" src="https://github.com/user-attachments/assets/c09ce771-2b9d-4a41-ae7d-291e4ecc5b62" />
